### PR TITLE
Added user confirm prompt before updating and deleting mesh

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"@oclif/errors": "^1.1.2",
 		"axios": "^0.23.0",
 		"dotenv": "^16.0.1",
+		"inquirer": "^8.2.4",
 		"pino": "^7.9.2",
 		"pino-pretty": "^7.6.0",
 		"uuid": "^8.3.2"

--- a/src/commands/api-mesh/delete.js
+++ b/src/commands/api-mesh/delete.js
@@ -10,8 +10,9 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command');
+
 const logger = require('../../classes/logger');
-const { initSdk, initRequestId } = require('../../helpers');
+const { initSdk, initRequestId, promptConfirm } = require('../../helpers');
 
 require('dotenv').config();
 
@@ -27,23 +28,31 @@ class DeleteCommand extends Command {
 
 		const { schemaServiceClient, imsOrgId, projectId, workspaceId } = await initSdk();
 
-		try {
-			const response = await schemaServiceClient.deleteMesh(
-				imsOrgId,
-				projectId,
-				workspaceId,
-				args.meshId,
-			);
+		const shouldContinue = await promptConfirm(
+			`Are you sure you want to delete the mesh: ${args.meshId}?`,
+		);
 
-			this.log('Successfully deleted mesh %s', args.meshId);
+		if (shouldContinue) {
+			try {
+				const response = await schemaServiceClient.deleteMesh(
+					imsOrgId,
+					projectId,
+					workspaceId,
+					args.meshId,
+				);
 
-			return response;
-		} catch (error) {
-			this.log(error.message);
+				this.log('Successfully deleted mesh %s', args.meshId);
 
-			this.error(
-				`Unable to delete mesh. Please check the details and try again. If the error persists please contact support. RequestId: ${global.requestId}`,
-			);
+				return response;
+			} catch (error) {
+				this.log(error.message);
+
+				this.error(
+					`Unable to delete mesh. Please check the details and try again. If the error persists please contact support. RequestId: ${global.requestId}`,
+				);
+			}
+		} else {
+			this.log('Delete cancelled');
 		}
 	}
 }

--- a/src/commands/api-mesh/delete.js
+++ b/src/commands/api-mesh/delete.js
@@ -53,6 +53,8 @@ class DeleteCommand extends Command {
 			}
 		} else {
 			this.log('Delete cancelled');
+
+			return 'Delete cancelled';
 		}
 	}
 }

--- a/src/commands/api-mesh/update.js
+++ b/src/commands/api-mesh/update.js
@@ -39,12 +39,12 @@ class UpdateCommand extends Command {
 			);
 		}
 
-		try {
-			const shouldContinue = await promptConfirm(
-				`Are you sure you want to update the mesh: ${args.meshId}?`,
-			);
+		const shouldContinue = await promptConfirm(
+			`Are you sure you want to update the mesh: ${args.meshId}?`,
+		);
 
-			if (shouldContinue) {
+		if (shouldContinue) {
+			try {
 				const response = await schemaServiceClient.updateMesh(
 					imsOrgId,
 					projectId,
@@ -56,17 +56,17 @@ class UpdateCommand extends Command {
 				this.log('Successfully updated the mesh with the id: %s', args.meshId);
 
 				return response;
-			} else {
-				this.log('Update cancelled');
+			} catch (error) {
+				this.log(error.message);
 
-				return;
+				this.error(
+					`Unable to update the mesh. Please check the mesh configuration file and try again. If the error persists please contact support. RequestId: ${global.requestId}`,
+				);
 			}
-		} catch (error) {
-			this.log(error.message);
+		} else {
+			this.log('Update cancelled');
 
-			this.error(
-				`Unable to update the mesh. Please check the mesh configuration file and try again. If the error persists please contact support. RequestId: ${global.requestId}`,
-			);
+			return 'Update cancelled';
 		}
 	}
 }

--- a/src/commands/api-mesh/update.js
+++ b/src/commands/api-mesh/update.js
@@ -11,8 +11,9 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/command');
 const { readFile } = require('fs/promises');
+
 const logger = require('../../classes/logger');
-const { initSdk, initRequestId } = require('../../helpers');
+const { initSdk, initRequestId, promptConfirm } = require('../../helpers');
 
 class UpdateCommand extends Command {
 	static args = [{ name: 'meshId' }, { name: 'file' }];
@@ -39,17 +40,27 @@ class UpdateCommand extends Command {
 		}
 
 		try {
-			const response = await schemaServiceClient.updateMesh(
-				imsOrgId,
-				projectId,
-				workspaceId,
-				args.meshId,
-				data,
+			const confirm = await promptConfirm(
+				`Are you sure you want to update the mesh: ${args.meshId}?`,
 			);
 
-			this.log('Successfully updated the mesh with the id: %s', args.meshId);
+			if (confirm) {
+				const response = await schemaServiceClient.updateMesh(
+					imsOrgId,
+					projectId,
+					workspaceId,
+					args.meshId,
+					data,
+				);
 
-			return response;
+				this.log('Successfully updated the mesh with the id: %s', args.meshId);
+
+				return response;
+			} else {
+				this.log('Update cancelled');
+
+				return;
+			}
 		} catch (error) {
 			this.log(error.message);
 

--- a/src/commands/api-mesh/update.js
+++ b/src/commands/api-mesh/update.js
@@ -40,11 +40,11 @@ class UpdateCommand extends Command {
 		}
 
 		try {
-			const confirm = await promptConfirm(
+			const shouldContinue = await promptConfirm(
 				`Are you sure you want to update the mesh: ${args.meshId}?`,
 			);
 
-			if (confirm) {
+			if (shouldContinue) {
 				const response = await schemaServiceClient.updateMesh(
 					imsOrgId,
 					projectId,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -209,6 +209,7 @@ async function promptConfirm(message) {
 			message,
 		},
 	]);
+
 	return confirm.res;
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,19 +9,21 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const fs = require('fs');
+const inquirer = require('inquirer');
+
 const Config = require('@adobe/aio-lib-core-config');
 const { getToken, context } = require('@adobe/aio-lib-ims');
 const { CLI } = require('@adobe/aio-lib-ims/src/context');
-const fs = require('fs');
 const libConsoleCLI = require('@adobe/aio-cli-lib-console');
-const { SchemaServiceClient } = require('./classes/SchemaServiceClient');
 const { getCliEnv } = require('@adobe/aio-lib-env');
+const aioConsoleLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-plugin-api-mesh', {
+	provider: 'debug',
+});
+
+const { SchemaServiceClient } = require('./classes/SchemaServiceClient');
 const logger = require('../src/classes/logger');
 const { UUID } = require('./classes/UUID');
-const aioConsoleLogger = require('@adobe/aio-lib-core-logging')(
-	'@adobe/aio-cli-plugin-api-mesh',
-	{ provider: 'debug' },
-);
 
 const CONSOLE_API_KEYS = {
 	prod: 'aio-cli-console-auth',
@@ -190,7 +192,29 @@ async function initRequestId() {
 	global.requestId = UUID.newUuid().toString();
 }
 
+/**
+ * Function to run the CLI Y/N prompt to confirm the user's action
+ *
+ * @param {string} message
+ *
+ * @returns boolean
+ */
+async function promptConfirm(message) {
+	const prompt = inquirer.createPromptModule({ output: process.stderr });
+
+	const confirm = await prompt([
+		{
+			type: 'confirm',
+			name: 'res',
+			message,
+		},
+	]);
+	return confirm.res;
+}
+
 module.exports = {
+	promptConfirm,
+	getLibConsoleCLI,
 	getDevConsoleConfig,
 	initSdk,
 	initRequestId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,7 +1548,7 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-bl@^4.0.3:
+bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -1719,7 +1719,7 @@ chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1803,7 +1803,7 @@ cli-progress@^3.4.0:
   dependencies:
     string-width "^4.2.0"
 
-cli-spinners@^2.2.0:
+cli-spinners@^2.2.0, cli-spinners@^2.5.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
   integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
@@ -3357,6 +3357,27 @@ inquirer@^7.3.3:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+inquirer@^8.2.4:
+  version "8.2.4"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.4.tgz#ddbfe86ca2f67649a67daa6f1051c128f684f0b4"
+  integrity sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^7.0.0"
+
 internal-slot@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.3.tgz#7347e307deeea2faac2ac6205d4bc7d34967f59c"
@@ -3613,6 +3634,11 @@ is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-weakref@^1.0.2:
   version "1.0.2"
@@ -4454,6 +4480,14 @@ log-symbols@^3.0.0:
   dependencies:
     chalk "^2.4.2"
 
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
+
 logform@^2.3.2, logform@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/logform/-/logform-2.4.0.tgz#131651715a17d50f09c2a2c1a524ff1a4164bcfe"
@@ -4854,6 +4888,21 @@ ora@^4.0.3, ora@^4.0.4:
     is-interactive "^1.0.0"
     log-symbols "^3.0.0"
     mute-stream "0.0.8"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
+ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
@@ -5412,6 +5461,13 @@ rxjs@^6.6.0, rxjs@^6.6.2:
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.5.5:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
+  integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
+  dependencies:
+    tslib "^2.1.0"
 
 safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -6079,7 +6135,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.2.0, tslib@^2.3.1:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added functionality to confirm with the user before performing update and delete actions.

![image](https://user-images.githubusercontent.com/35203638/172475287-fe475762-99de-4216-81ac-5b2a5009b521.png)

This PR uses the same package that `aio` plugins use for CLI interactions. `inquirer` is a very famous and safe package to use.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-499

## Motivation and Context

Trying to avoid user error.

## How Has This Been Tested?

Yes

## Screenshots (if appropriate):

In Desc

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
