### PR TITLE
Added auto api key creation and subscription feature

### DIFF
--- a/src/classes/SchemaServiceClient.js
+++ b/src/classes/SchemaServiceClient.js
@@ -491,7 +491,7 @@ class SchemaServiceClient {
 		};
 		const credentialConfig = {
 			method: 'post',
-			url: `${this.devConsoleUrl}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/credentials/adobeid`,
+			url: `${this.devConsoleUrl}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/credentials/adobeId`,
 			headers: {
 				'Authorization': `Bearer ${this.accessToken}`,
 				'Content-Type': 'application/json',

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -13,7 +13,6 @@ governing permissions and limitations under the License.
 const mockConsoleCLIInstance = {};
 
 const CreateCommand = require('../create');
-// const { SchemaServiceClient } = require('../../../classes/SchemaServiceClient');
 const sampleCreateMeshConfig = require('../../__fixtures__/sample_mesh.json');
 const { initSdk, initRequestId } = require('../../../helpers');
 
@@ -278,6 +277,42 @@ describe('create command tests', () => {
 		const runResult = await CreateCommand.run(['src/commands/__fixtures__/sample_mesh.json']);
 
 		expect(initRequestId).toHaveBeenCalled();
+		expect(mockCreateMesh.mock.calls[0]).toMatchInlineSnapshot(`
+		Array [
+		  "1234",
+		  "5678",
+		  "123456789",
+		  Object {
+		    "meshConfig": Object {
+		      "sources": Array [
+		        Object {
+		          "handler": Object {
+		            "graphql": Object {
+		              "endpoint": "<gql_endpoint>",
+		            },
+		          },
+		          "name": "<api_name>",
+		        },
+		      ],
+		    },
+		  },
+		]
+	`);
+		expect(mockCreateAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
+		Array [
+		  "1234",
+		  "5678",
+		  "123456789",
+		]
+	`);
+		expect(mockSubscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
+		Array [
+		  "1234",
+		  "5678",
+		  "123456789",
+		  "dummy_id",
+		]
+	`);
 		expect(runResult).toMatchInlineSnapshot(`
 		Object {
 		  "adobeIdIntegrationsForWorkspace": Object {

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -12,8 +12,10 @@ governing permissions and limitations under the License.
 
 const mockConsoleCLIInstance = {};
 
-jest.mock('@adobe/aio-lib-env');
-jest.mock('@adobe/aio-cli-lib-console');
+const CreateCommand = require('../create');
+// const { SchemaServiceClient } = require('../../../classes/SchemaServiceClient');
+const sampleCreateMeshConfig = require('../../__fixtures__/sample_mesh.json');
+const { initSdk, initRequestId } = require('../../../helpers');
 
 const orgs = [{ id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }];
 const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' };
@@ -37,39 +39,306 @@ function setDefaultMockConsoleCLI() {
 	mockConsoleCLIInstance.getWorkspaces = jest.fn().mockResolvedValue(workspaces);
 	mockConsoleCLIInstance.promptForSelectWorkspace = jest.fn().mockResolvedValue(selectedWorkspace);
 }
+
+const mockCreateMesh = jest.fn().mockResolvedValue({
+	meshId: 'dummy_mesh_id',
+	meshConfig: sampleCreateMeshConfig.meshConfig,
+});
+
+const mockCreateAPIMeshCredentials = jest.fn().mockResolvedValue({
+	apiKey: 'dummy_api_key',
+	id: 'dummy_id',
+});
+
+const mockSubscribeCredentialToMeshService = jest.fn().mockResolvedValue([
+	{
+		service: 'dummy_service',
+	},
+]);
+
+const mockSchemaServiceClient = {
+	createMesh: mockCreateMesh,
+	createAPIMeshCredentials: mockCreateAPIMeshCredentials,
+	subscribeCredentialToMeshService: mockSubscribeCredentialToMeshService,
+};
+
 jest.mock('@adobe/aio-cli-lib-console', () => ({
 	init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
 	cleanStdOut: jest.fn(),
 }));
+
+jest.mock('axios');
 jest.mock('@adobe/aio-lib-ims');
-const CreateCommand = require('../create');
-const { SchemaServiceClient } = require('../../../classes/SchemaServiceClient');
-const mockCreateMesh = require('../../__fixtures__/sample_mesh.json');
+jest.mock('@adobe/aio-lib-env');
+jest.mock('@adobe/aio-cli-lib-console');
+jest.mock('../../../helpers', () => ({
+	initSdk: jest.fn().mockResolvedValue({}),
+	initRequestId: jest.fn().mockResolvedValue({}),
+}));
+
+let logSpy = null;
+let errorLogSpy = null;
 
 describe('create command tests', () => {
 	beforeEach(() => {
 		setDefaultMockConsoleCLI();
-		const response = mockCreateMesh;
-		jest.spyOn(SchemaServiceClient.prototype, 'createMesh').mockImplementation(data => response);
+
+		initSdk.mockResolvedValue({
+			schemaServiceClient: mockSchemaServiceClient,
+			imsOrgId: selectedOrg.id,
+			projectId: selectedProject.id,
+			workspaceId: selectedWorkspace.id,
+		});
+
+		global.requestId = 'dummy_request_id';
+
+		logSpy = jest.spyOn(CreateCommand.prototype, 'log');
+		errorLogSpy = jest.spyOn(CreateCommand.prototype, 'error');
 	});
 
 	afterEach(() => {
 		jest.restoreAllMocks();
 	});
 
-	test('should fail mesh id is missing', async () => {
-		expect.assertions(2);
-		const runResult = CreateCommand.run([]);
-		await expect(runResult instanceof Promise).toBeTruthy();
-		await expect(runResult).rejects.toEqual(
-			new Error('Missing file path. Run aio api-mesh create --help for more info.'),
+	test('snapshot create command description', () => {
+		expect(CreateCommand.description).toMatchInlineSnapshot(
+			`"Create a mesh with the given config."`,
 		);
 	});
 
-	test('create-mesh-with-configuration', async () => {
-		expect.assertions(2);
+	test('should fail if mesh config file arg is missing', async () => {
+		const runResult = CreateCommand.run([]);
+
+		await expect(runResult).rejects.toEqual(
+			new Error('Missing file path. Run aio api-mesh create --help for more info.'),
+		);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`Array []`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Missing file path. Run aio api-mesh create --help for more info.",
+		  ],
+		]
+	`);
+	});
+
+	test('should fail if mesh file is invalid', async () => {
+		const runResult = CreateCommand.run(['invalid_file_path']);
+
+		await expect(runResult).rejects.toEqual(
+			new Error(
+				'Unable to read the mesh configuration file provided. Please check the file and try again.',
+			),
+		);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "ENOENT: no such file or directory, open 'invalid_file_path'",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Unable to read the mesh configuration file provided. Please check the file and try again.",
+		  ],
+		]
+	`);
+	});
+
+	test('should fail if create mesh api has failed', async () => {
+		mockCreateMesh.mockRejectedValueOnce(new Error('create mesh api failed'));
+
 		const runResult = CreateCommand.run(['src/commands/__fixtures__/sample_mesh.json']);
-		await expect(runResult instanceof Promise).toBeTruthy();
-		await expect(runResult).resolves.toEqual(mockCreateMesh);
+
+		await expect(runResult).rejects.toEqual(
+			new Error(
+				'Unable to create a mesh. Please check the mesh configuration file and try again. If the error persists please contact support. RequestId: dummy_request_id',
+			),
+		);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "create mesh api failed",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Unable to create a mesh. Please check the mesh configuration file and try again. If the error persists please contact support. RequestId: dummy_request_id",
+		  ],
+		]
+	`);
+	});
+
+	test('should fail if create api credential api has failed', async () => {
+		mockCreateAPIMeshCredentials.mockRejectedValueOnce(
+			new Error('create api credential api failed'),
+		);
+
+		const runResult = CreateCommand.run(['src/commands/__fixtures__/sample_mesh.json']);
+
+		await expect(runResult).rejects.toEqual(
+			new Error(
+				'Unable to create a mesh. Please check the mesh configuration file and try again. If the error persists please contact support. RequestId: dummy_request_id',
+			),
+		);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Successfully created mesh %s",
+		    "dummy_mesh_id",
+		  ],
+		  Array [
+		    "{
+		  \\"meshId\\": \\"dummy_mesh_id\\",
+		  \\"meshConfig\\": {
+		    \\"sources\\": [
+		      {
+		        \\"name\\": \\"<api_name>\\",
+		        \\"handler\\": {
+		          \\"graphql\\": {
+		            \\"endpoint\\": \\"<gql_endpoint>\\"
+		          }
+		        }
+		      }
+		    ]
+		  }
+		}",
+		  ],
+		  Array [
+		    "create api credential api failed",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Unable to create a mesh. Please check the mesh configuration file and try again. If the error persists please contact support. RequestId: dummy_request_id",
+		  ],
+		]
+	`);
+	});
+
+	test('should fail if subscribe credential to mesh service api has failed', async () => {
+		mockSubscribeCredentialToMeshService.mockRejectedValueOnce(
+			new Error('subscribe credential to mesh service api failed'),
+		);
+
+		const runResult = CreateCommand.run(['src/commands/__fixtures__/sample_mesh.json']);
+
+		await expect(runResult).rejects.toEqual(
+			new Error(
+				'Unable to create a mesh. Please check the mesh configuration file and try again. If the error persists please contact support. RequestId: dummy_request_id',
+			),
+		);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Successfully created mesh %s",
+		    "dummy_mesh_id",
+		  ],
+		  Array [
+		    "{
+		  \\"meshId\\": \\"dummy_mesh_id\\",
+		  \\"meshConfig\\": {
+		    \\"sources\\": [
+		      {
+		        \\"name\\": \\"<api_name>\\",
+		        \\"handler\\": {
+		          \\"graphql\\": {
+		            \\"endpoint\\": \\"<gql_endpoint>\\"
+		          }
+		        }
+		      }
+		    ]
+		  }
+		}",
+		  ],
+		  Array [
+		    "Successfully created API Key %s",
+		    "dummy_api_key",
+		  ],
+		  Array [
+		    "subscribe credential to mesh service api failed",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Unable to create a mesh. Please check the mesh configuration file and try again. If the error persists please contact support. RequestId: dummy_request_id",
+		  ],
+		]
+	`);
+	});
+
+	test('should create if a valid mesh config file is provided', async () => {
+		const runResult = await CreateCommand.run(['src/commands/__fixtures__/sample_mesh.json']);
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(runResult).toMatchInlineSnapshot(`
+		Object {
+		  "adobeIdIntegrationsForWorkspace": Object {
+		    "apiKey": "dummy_api_key",
+		    "id": "dummy_id",
+		  },
+		  "mesh": Object {
+		    "meshConfig": Object {
+		      "sources": Array [
+		        Object {
+		          "handler": Object {
+		            "graphql": Object {
+		              "endpoint": "<gql_endpoint>",
+		            },
+		          },
+		          "name": "<api_name>",
+		        },
+		      ],
+		    },
+		    "meshId": "dummy_mesh_id",
+		  },
+		  "sdkList": Array [
+		    Object {
+		      "service": "dummy_service",
+		    },
+		  ],
+		}
+	`);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Successfully created mesh %s",
+		    "dummy_mesh_id",
+		  ],
+		  Array [
+		    "{
+		  \\"meshId\\": \\"dummy_mesh_id\\",
+		  \\"meshConfig\\": {
+		    \\"sources\\": [
+		      {
+		        \\"name\\": \\"<api_name>\\",
+		        \\"handler\\": {
+		          \\"graphql\\": {
+		            \\"endpoint\\": \\"<gql_endpoint>\\"
+		          }
+		        }
+		      }
+		    ]
+		  }
+		}",
+		  ],
+		  Array [
+		    "Successfully created API Key %s",
+		    "dummy_api_key",
+		  ],
+		  Array [
+		    "Successfully subscribed API Key %s to API Mesh service",
+		    "dummy_api_key",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`Array []`);
 	});
 });

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -11,8 +11,23 @@ governing permissions and limitations under the License.
 */
 
 const mockConsoleCLIInstance = {};
+
+jest.mock('axios');
 jest.mock('@adobe/aio-lib-env');
 jest.mock('@adobe/aio-cli-lib-console');
+jest.mock('@adobe/aio-lib-ims');
+jest.mock('../../../helpers', () => ({
+	initSdk: jest.fn().mockResolvedValue({}),
+	initRequestId: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('@adobe/aio-cli-lib-console', () => ({
+	init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
+	cleanStdOut: jest.fn(),
+}));
+
+const DescribeCommand = require('../describe');
+const { initSdk, initRequestId } = require('../../../helpers');
+
 const orgs = [{ id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' }];
 const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' };
 
@@ -36,44 +51,199 @@ function setDefaultMockConsoleCLI() {
 	mockConsoleCLIInstance.promptForSelectWorkspace = jest.fn().mockResolvedValue(selectedWorkspace);
 }
 
-jest.mock('@adobe/aio-cli-lib-console', () => ({
-	init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
-	cleanStdOut: jest.fn(),
-}));
+const mockDescribeMesh = jest.fn().mockResolvedValue({
+	meshId: 'dummy_meshId',
+	apiKey: 'dummy_apiKey',
+});
 
-jest.mock('@adobe/aio-lib-ims');
+const mockSchemaServiceClient = {
+	describeMesh: mockDescribeMesh,
+};
 
-const DescribeCommand = require('../describe');
-const { SchemaServiceClient } = require('../../../classes/SchemaServiceClient');
+let logSpy = null;
+let errorLogSpy = null;
 
 describe('describe command tests', () => {
 	beforeEach(() => {
 		setDefaultMockConsoleCLI();
+
+		initSdk.mockResolvedValue({
+			schemaServiceClient: mockSchemaServiceClient,
+			imsOrgId: selectedOrg.id,
+			projectId: selectedProject.id,
+			workspaceId: selectedWorkspace.id,
+		});
+
+		global.requestId = 'dummy_request_id';
+
+		logSpy = jest.spyOn(DescribeCommand.prototype, 'log');
+		errorLogSpy = jest.spyOn(DescribeCommand.prototype, 'error');
 	});
 
 	afterEach(() => {
 		jest.restoreAllMocks();
 	});
 
-	test('should error if wrong details are provided', async () => {
-		const runResult = DescribeCommand.run([]);
-
-		return runResult.catch(err => {
-			expect(err).toHaveProperty(
-				'message',
-				expect.stringMatching(
-					/^Unable to get mesh details\. Please check the details and try again\. If the error persists please contact support\. RequestId: [a-z A-Z 0-9 -_]+/,
-				),
-			);
-		});
+	test('snapshot create command description', () => {
+		expect(DescribeCommand.description).toMatchInlineSnapshot(`"Get details of a mesh"`);
 	});
 
-	test('should return meshId if correct details are provided', async () => {
-		const meshId = 'sample-mesh-id';
-		jest.spyOn(SchemaServiceClient.prototype, 'describeMesh').mockResolvedValue({ meshId });
+	test('should error if describe api has failed', async () => {
+		mockDescribeMesh.mockRejectedValueOnce(new Error('describe api failed'));
+
+		const runResult = DescribeCommand.run();
+
+		await expect(runResult).rejects.toEqual(
+			new Error(
+				'Unable to get mesh details. Please check the details and try again. If the error persists please contact support. RequestId: dummy_request_id',
+			),
+		);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "describe api failed",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Unable to get mesh details. Please check the details and try again. If the error persists please contact support. RequestId: dummy_request_id",
+		  ],
+		]
+	`);
+	});
+
+	test('should error if mesh details is missing from describe api response', async () => {
+		mockDescribeMesh.mockResolvedValueOnce(null);
+
+		const runResult = DescribeCommand.run();
+
+		await expect(runResult).rejects.toEqual(
+			new Error(
+				'Unable to get mesh details. Please check the details and try again. If the error persists please contact support. RequestId: dummy_request_id',
+			),
+		);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Unable to get mesh details",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Unable to get mesh details. Please check the details and try again. If the error persists please contact support. RequestId: dummy_request_id",
+		  ],
+		]
+	`);
+	});
+
+	test('should error if mesh id is missing from describe api response', async () => {
+		mockDescribeMesh.mockResolvedValueOnce({});
 
 		const runResult = await DescribeCommand.run();
 
-		await expect(runResult).toEqual({ meshId });
+		expect(runResult).toBe(undefined);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`Array []`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Unable to get mesh details. Please check the details and try again. RequestId: dummy_request_id",
+		    Object {
+		      "exit": false,
+		    },
+		  ],
+		]
+	`);
+	});
+
+	test('should not fail if api key is missing from mesh details', async () => {
+		mockDescribeMesh.mockResolvedValueOnce({ meshId: 'dummy_meshId' });
+
+		const runResult = await DescribeCommand.run();
+
+		expect(runResult).toMatchInlineSnapshot(`
+		Object {
+		  "meshId": "dummy_meshId",
+		}
+	`);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Successfully retrieved mesh details 
+		",
+		  ],
+		  Array [
+		    "Org ID: %s",
+		    "1234",
+		  ],
+		  Array [
+		    "Project ID: %s",
+		    "5678",
+		  ],
+		  Array [
+		    "Workspace ID: %s",
+		    "123456789",
+		  ],
+		  Array [
+		    "Mesh ID: %s",
+		    "dummy_meshId",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`Array []`);
+	});
+
+	test('should succeed if valid details are provided', async () => {
+		const runResult = await DescribeCommand.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(mockDescribeMesh).toHaveBeenCalledWith(
+			selectedOrg.id,
+			selectedProject.id,
+			selectedWorkspace.id,
+		);
+		expect(runResult).toMatchInlineSnapshot(`
+		Object {
+		  "apiKey": "dummy_apiKey",
+		  "meshId": "dummy_meshId",
+		}
+	`);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		Array [
+		  Array [
+		    "Successfully retrieved mesh details 
+		",
+		  ],
+		  Array [
+		    "Org ID: %s",
+		    "1234",
+		  ],
+		  Array [
+		    "Project ID: %s",
+		    "5678",
+		  ],
+		  Array [
+		    "Workspace ID: %s",
+		    "123456789",
+		  ],
+		  Array [
+		    "Mesh ID: %s",
+		    "dummy_meshId",
+		  ],
+		  Array [
+		    "API Key: %s",
+		    "dummy_apiKey",
+		  ],
+		  Array [
+		    "Mesh Endpoint: %s
+		",
+		    "https://graph.adobe.io/api/dummy_meshId/graphql?api_key=dummy_apiKey",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`Array []`);
 	});
 });

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -68,7 +68,22 @@ class CreateCommand extends Command {
 						workspaceId,
 						adobeIdIntegrationsForWorkspace.id,
 					);
+
+					if (sdkList) {
+						this.log(
+							'Successfully subscribed API Key %s to API Mesh service',
+							adobeIdIntegrationsForWorkspace.apiKey,
+						);
+					} else {
+						this.log(
+							'Unable to subscribe API Key %s to API Mesh service',
+							adobeIdIntegrationsForWorkspace.apiKey,
+						);
+					}
+				} else {
+					this.log('Unable to create API Key');
 				}
+
 				return {
 					adobeIdIntegrationsForWorkspace,
 					sdkList,

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -47,12 +47,33 @@ class CreateCommand extends Command {
 
 		try {
 			const mesh = await schemaServiceClient.createMesh(imsOrgId, projectId, workspaceId, data);
+			let sdkList = [];
 
 			if (mesh) {
 				this.log('Successfully created mesh %s', mesh.meshId);
 				this.log(JSON.stringify(mesh, null, 2));
+				// create API key credential
+				const adobeIdIntegrationsForWorkspace = await schemaServiceClient.createAPIMeshCredentials(
+					imsOrgId,
+					projectId,
+					workspaceId,
+				);
 
-				return mesh;
+				if (adobeIdIntegrationsForWorkspace) {
+					this.log('Successfully created API Key %s', adobeIdIntegrationsForWorkspace.apiKey);
+					// subscribe the credential to API mesh service
+					sdkList = await schemaServiceClient.subscribeCredentialToMeshService(
+						imsOrgId,
+						projectId,
+						workspaceId,
+						adobeIdIntegrationsForWorkspace.id,
+					);
+				}
+				return {
+					adobeIdIntegrationsForWorkspace,
+					sdkList,
+					mesh,
+				};
 			} else {
 				this.error(`Unable to create a mesh. Please try again. RequestId: ${global.requestId}`, {
 					exit: false,

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -10,10 +10,14 @@ governing permissions and limitations under the License.
 */
 
 const { Command } = require('@oclif/command');
+
 const logger = require('../../classes/logger');
 const { initSdk, initRequestId } = require('../../helpers');
+const CONSTANTS = require('../../constants');
 
 require('dotenv').config();
+
+const { MULTITENANT_GRAPHQL_SERVER_BASE_URL } = CONSTANTS;
 
 class DescribeCommand extends Command {
 	async run() {
@@ -27,7 +31,7 @@ class DescribeCommand extends Command {
 			const meshDetails = await schemaServiceClient.describeMesh(imsOrgId, projectId, workspaceId);
 
 			if (meshDetails) {
-				const { meshId } = meshDetails;
+				const { meshId, apiKey } = meshDetails;
 
 				if (meshId) {
 					this.log('Successfully retrieved mesh details \n');
@@ -35,6 +39,14 @@ class DescribeCommand extends Command {
 					this.log('Project ID: %s', projectId);
 					this.log('Workspace ID: %s', workspaceId);
 					this.log('Mesh ID: %s', meshId);
+
+					if (apiKey) {
+						this.log('API Key: %s', apiKey);
+						this.log(
+							'Mesh Endpoint: %s\n',
+							`${MULTITENANT_GRAPHQL_SERVER_BASE_URL}/${meshId}/graphql?api_key=${apiKey}`,
+						);
+					}
 
 					return meshDetails;
 				} else {

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ const StageConstants = {
 	MULTITENANT_GRAPHQL_SERVER_BASE_URL: 'https://graph-stage.adobe.io/api',
 	DEV_CONSOLE_BASE_URL: 'https://developers-stage.adobe.io/console',
 	DEV_CONSOLE_API_KEY: 'adobe-api-manager-sms-stage',
+	DEV_CONSOLE_TRANSPORTER_API_KEY: 'UDPWeb1',
 	AIO_CLI_API_KEY: 'aio-cli-console-auth-stage',
 };
 
@@ -13,6 +14,7 @@ const ProdConstants = {
 	MULTITENANT_GRAPHQL_SERVER_BASE_URL: 'https://graph.adobe.io/api',
 	DEV_CONSOLE_BASE_URL: 'https://developers.adobe.io/console',
 	DEV_CONSOLE_API_KEY: 'adobe-graph-prod',
+	DEV_CONSOLE_TRANSPORTER_API_KEY: 'UDPWeb1',
 	AIO_CLI_API_KEY: 'aio-cli-console-auth',
 };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,19 @@
+const { getCliEnv } = require('@adobe/aio-lib-env');
+
+const clientEnv = getCliEnv();
+
+const StageConstants = {
+	MULTITENANT_GRAPHQL_SERVER_BASE_URL: 'https://graph-stage.adobe.io/api',
+	DEV_CONSOLE_BASE_URL: 'https://developers-stage.adobe.io/console',
+	DEV_CONSOLE_API_KEY: 'adobe-api-manager-sms-stage',
+	AIO_CLI_API_KEY: 'aio-cli-console-auth-stage',
+};
+
+const ProdConstants = {
+	MULTITENANT_GRAPHQL_SERVER_BASE_URL: 'https://graph.adobe.io/api',
+	DEV_CONSOLE_BASE_URL: 'https://developers.adobe.io/console',
+	DEV_CONSOLE_API_KEY: 'adobe-graph-prod',
+	AIO_CLI_API_KEY: 'aio-cli-console-auth',
+};
+
+module.exports = clientEnv === 'stage' ? StageConstants : ProdConstants;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,11 +24,9 @@ const aioConsoleLogger = require('@adobe/aio-lib-core-logging')('@adobe/aio-cli-
 const { SchemaServiceClient } = require('./classes/SchemaServiceClient');
 const logger = require('../src/classes/logger');
 const { UUID } = require('./classes/UUID');
+const CONSTANTS = require('./constants');
 
-const CONSOLE_API_KEYS = {
-	prod: 'aio-cli-console-auth',
-	stage: 'aio-cli-console-auth-stage',
-};
+const { DEV_CONSOLE_BASE_URL, DEV_CONSOLE_API_KEY, AIO_CLI_API_KEY } = CONSTANTS;
 
 /**
  * @returns {any} Returns a config object or null
@@ -38,9 +36,9 @@ async function getDevConsoleConfig() {
 
 	if (!configFile) {
 		return {
-			baseUrl: 'https://developers.adobe.io/console',
+			baseUrl: DEV_CONSOLE_BASE_URL,
 			accessToken: (await getLibConsoleCLI()).accessToken,
-			apiKey: 'adobe-graph-prod',
+			apiKey: DEV_CONSOLE_API_KEY,
 		};
 	} else {
 		try {
@@ -151,7 +149,7 @@ async function getLibConsoleCLI() {
 
 	const consoleCLI = await libConsoleCLI.init({
 		accessToken: accessToken,
-		apiKey: CONSOLE_API_KEYS[clientEnv],
+		apiKey: AIO_CLI_API_KEY,
 		env: clientEnv,
 	});
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added feature to automatically create API Keys while creating meshes and subscribing them to the API Mesh Service. This will reflect on the dev console UI as well. Also, a new feature has been added to describe command to retrieve API Keys if available on the workspace.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-701

## Motivation and Context

Dev Experience

## How Has This Been Tested?

### Pre req

Check out the branch and link the plugin to local AIO CLI for testing

### Steps

1. Create a mesh on workspace that does not have a mesh already using the CREATE command (`aio api-mesh create <MESH.JSON>`) . If an API Key has been created, it will show up on the CLI.
2. Run the DESCRIBE command (`aio api-mesh describe`) on the workspace used above to retrieve the mesh details and the URL to run a query against.

## Screenshots (if appropriate):

Create

![image](https://user-images.githubusercontent.com/35203638/183500953-5aad014e-e7f9-4388-890d-a8c1f40bd4c6.png)

Describe

![image](https://user-images.githubusercontent.com/35203638/183501075-c78c2341-1f14-41e1-a3f8-d26ecaaa4e74.png)

Console

![image](https://user-images.githubusercontent.com/35203638/183501109-8931baf6-e29f-46d4-95ea-5d01cd7fcc1c.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
