### PR TITLE
CEXT-815: A flag to provide json output is needed for the aio api-mesh cli

### DIFF
--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -356,7 +356,6 @@ describe('create command tests', () => {
 		    "apiKey": "dummy_api_key",
 		    "id": "dummy_id",
 		  },
-		  "endpoint": "https://graph.adobe.io/api/dummy_mesh_id/graphql?api_key=dummy_api_key",
 		  "mesh": Object {
 		    "meshConfig": Object {
 		      "sources": Array [
@@ -493,5 +492,19 @@ describe('create command tests', () => {
 		]
 	`);
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`Array []`);
+	});
+
+	test('must return proper object structure used by adobe/generator-app-api-mesh', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_mesh.json' },
+			flags: {
+				json: Promise.resolve(true)
+			},
+		});
+		const output = await CreateCommand.run()
+		expect(output).toHaveProperty('mesh')
+		expect(output).toHaveProperty('adobeIdIntegrationsForWorkspace')
+		expect(output.mesh).toEqual(expect.objectContaining({ meshId: 'dummy_mesh_id' }));
+		expect(output.adobeIdIntegrationsForWorkspace).toEqual(expect.objectContaining({ apiKey: 'dummy_api_key' })); 
 	});
 });

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -117,6 +117,14 @@ describe('create command tests', () => {
 		    "parse": [Function],
 		    "type": "boolean",
 		  },
+		  "json": Object {
+		    "allowNo": false,
+		    "char": "j",
+		    "default": false,
+		    "description": "Output JSON",
+		    "parse": [Function],
+		    "type": "boolean",
+		  },
 		}
 	`);
 		expect(CreateCommand.aliases).toMatchInlineSnapshot(`Array []`);
@@ -348,6 +356,7 @@ describe('create command tests', () => {
 		    "apiKey": "dummy_api_key",
 		    "id": "dummy_id",
 		  },
+		  "endpoint": "https://graph.adobe.io/api/dummy_mesh_id/graphql?api_key=dummy_api_key",
 		  "mesh": Object {
 		    "meshConfig": Object {
 		      "sources": Array [

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -119,7 +119,6 @@ describe('create command tests', () => {
 		  },
 		  "json": Object {
 		    "allowNo": false,
-		    "char": "j",
 		    "default": false,
 		    "description": "Output JSON",
 		    "parse": [Function],

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -119,12 +119,12 @@ class CreateCommand extends Command {
 					} else {
 						this.log('Unable to create API Key');
 					}
-
+                    // Do not remove or rename return values.
+					// Template adobe/generator-app-api-mesh relies on "mesh" & "adobeIdIntegrationsForWorkspace" obj structure
 					return {
 						adobeIdIntegrationsForWorkspace,
 						sdkList,
-						mesh,
-						endpoint: `${MULTITENANT_GRAPHQL_SERVER_BASE_URL}/${mesh.meshId}/graphql?api_key=${adobeIdIntegrationsForWorkspace.apiKey}`
+						mesh
 					};
 				} else {
 					this.error(`Unable to create a mesh. Please try again. RequestId: ${global.requestId}`, {

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -9,13 +9,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const { Command } = require('@oclif/command');
+const { Command } = require('@oclif/core');
 const { readFile } = require('fs/promises');
 
 const { initSdk, initRequestId, promptConfirm } = require('../../helpers');
 const logger = require('../../classes/logger');
 const CONSTANTS = require('../../constants');
-const { ignoreCacheFlag, autoConfirmActionFlag } = require('../../utils');
+const { ignoreCacheFlag, autoConfirmActionFlag, jsonFlag } = require('../../utils');
 const {
 	createMesh,
 	createAPIMeshCredentials,
@@ -31,7 +31,10 @@ class CreateCommand extends Command {
 	static flags = {
 		ignoreCache: ignoreCacheFlag,
 		autoConfirmAction: autoConfirmActionFlag,
+		json: jsonFlag
 	};
+
+	static enableJsonFlag = true
 
 	async run() {
 		await initRequestId();
@@ -121,6 +124,7 @@ class CreateCommand extends Command {
 						adobeIdIntegrationsForWorkspace,
 						sdkList,
 						mesh,
+						endpoint: `${MULTITENANT_GRAPHQL_SERVER_BASE_URL}/${mesh.meshId}/graphql?api_key=${adobeIdIntegrationsForWorkspace.apiKey}`
 					};
 				} else {
 					this.error(`Unable to create a mesh. Please try again. RequestId: ${global.requestId}`, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,8 +49,16 @@ const autoConfirmActionFlag = Flags.boolean({
 	default: false,
 });
 
+const jsonFlag = Flags.boolean({
+	char: 'j',
+	description:
+		'Output JSON',
+	default: false,
+});
+
 module.exports = {
 	objToString,
 	ignoreCacheFlag,
 	autoConfirmActionFlag,
+	jsonFlag,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -50,7 +50,6 @@ const autoConfirmActionFlag = Flags.boolean({
 });
 
 const jsonFlag = Flags.boolean({
-	char: 'j',
 	description:
 		'Output JSON',
 	default: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added `--json` flag to `aio api-mesh create` command.

<img width="881" alt="Screen Shot 2022-11-15 at 11 23 39 AM" src="https://user-images.githubusercontent.com/17548019/201985892-d10d1cdf-7369-4501-84a2-cd0621b13c53.png">

## Related Issue
[DEVX-2485](https://jira.corp.adobe.com/browse/DEVX-2485): Integrate with aio api-mesh plugin

## Related PR
https://github.com/adobe/generator-app-api-mesh/pull/3

## Motivation and Context
This is needed for [adobe/generator-app-api-mesh](https://github.com/adobe/generator-app-api-mesh) in order to create sample API mesh when running `aio app init` using API Mesh Template.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
**Manual:**
Run `aio api-mesh create /path/to/config/mesh.json --json`

**Automated:**
Execute `create.test.js`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
