### PR TITLE
CEXT 1487

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "2.1.0",
+	"version": "1.4.0",
 	"publishConfig": {
 		"access": "public"
 	},
@@ -47,11 +47,12 @@
 		"jest": "^29.2.2",
 		"jest-junit": "^6.0.0",
 		"prettier": "2.2.1",
-		"stdout-stderr": "^0.1.9"
+		"stdout-stderr": "^0.1.9",
+		"jsmin": "1.0.1"
 	},
 	"engines": {
 		"npm": ">=8.0.0",
-		"node": "^16.13 || >=18.0.0"
+		"node": ">=18.0.0"
 	},
 	"files": [
 		"/oclif.manifest.json",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 	},
 	"engines": {
 		"npm": ">=8.0.0",
-		"node": ">=18.0.0"
+		"node": "^16.13 || >=18.0.0"
 	},
 	"files": [
 		"/oclif.manifest.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "1.4.0",
+	"version": "2.1.0",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "2.1.0",
+	"version": "2.3.0",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
 		"husky": "7.0.4",
 		"jest": "^29.2.2",
 		"jest-junit": "^6.0.0",
+		"jsmin": "1.0.1",
 		"prettier": "2.2.1",
-		"stdout-stderr": "^0.1.9",
-		"jsmin": "1.0.1"
+		"stdout-stderr": "^0.1.9"
 	},
 	"engines": {
 		"npm": ">=8.0.0",

--- a/src/commands/__fixtures__/files/requestParams.json
+++ b/src/commands/__fixtures__/files/requestParams.json
@@ -1,0 +1,3 @@
+{
+    "type": "updatedContent"
+}

--- a/src/commands/__fixtures__/openapi-schema.json
+++ b/src/commands/__fixtures__/openapi-schema.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema"
+    "id": "2"
+}

--- a/src/commands/__fixtures__/requestParams.json
+++ b/src/commands/__fixtures__/requestParams.json
@@ -1,0 +1,3 @@
+{
+    "type": "updatedContent"
+}

--- a/src/commands/__fixtures__/sample_fully_qualified_mesh.json
+++ b/src/commands/__fixtures__/sample_fully_qualified_mesh.json
@@ -1,0 +1,29 @@
+{
+    "meshConfig": {
+      "sources": [
+        {
+          "name": "<json_source_name>",
+          "handler": {
+            "JsonSchema": {
+              "baseUrl": "<json_source__baseurl>",
+              "operations": [
+                {
+                  "type": "Query",
+                  "field": "<query>",
+                  "path": "<query_path>",
+                  "method": "POST",
+                  "requestSchema": "./schemaBody.json"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "files": [
+        {
+          "path": "./schemaBody.json",
+          "content": "{\"type\":\"dummyContent\"}"
+        }
+      ]
+    }
+  }

--- a/src/commands/__fixtures__/sample_mesh_files.json
+++ b/src/commands/__fixtures__/sample_mesh_files.json
@@ -1,0 +1,23 @@
+{
+  "meshConfig":{
+     "sources":[
+        {
+           "name":"<json_source_name>",
+           "handler":{
+              "JsonSchema":{
+                 "baseUrl":"<json_source__baseurl>",
+                 "operations":[
+                    {
+                       "type":"Query",
+                       "field":"<query>",
+                       "path":"<query_path>",
+                       "method":"POST",
+                       "requestSchema":"./requestParams.json"
+                    }
+                 ]
+              }
+           }
+        }
+     ]
+  }
+}

--- a/src/commands/__fixtures__/sample_mesh_files.json
+++ b/src/commands/__fixtures__/sample_mesh_files.json
@@ -1,23 +1,23 @@
 {
-  "meshConfig":{
-     "sources":[
-        {
-           "name":"<json_source_name>",
-           "handler":{
-              "JsonSchema":{
-                 "baseUrl":"<json_source__baseurl>",
-                 "operations":[
-                    {
-                       "type":"Query",
-                       "field":"<query>",
-                       "path":"<query_path>",
-                       "method":"POST",
-                       "requestSchema":"./requestParams.json"
-                    }
-                 ]
+  "meshConfig": {
+    "sources": [
+      {
+        "name": "<json_source_name>",
+        "handler": {
+          "JsonSchema": {
+            "baseUrl": "<json_source__baseurl>",
+            "operations": [
+              {
+                "type": "Query",
+                "field": "<query>",
+                "path": "<query_path>",
+                "method": "POST",
+                "requestSchema": "./requestParams.json"
               }
-           }
+            ]
+          }
         }
-     ]
+      }
+    ]
   }
 }

--- a/src/commands/__fixtures__/sample_mesh_invalid_file_content.json
+++ b/src/commands/__fixtures__/sample_mesh_invalid_file_content.json
@@ -1,0 +1,14 @@
+{
+    "meshConfig":{
+       "sources":[
+          {
+             "name":"CurrencyAPI",
+             "handler":{
+                "openapi":{
+                   "source":"./openapi-schema.json"
+                }
+             }
+          }
+       ]
+    }
+ }

--- a/src/commands/__fixtures__/sample_mesh_invalid_file_name.json
+++ b/src/commands/__fixtures__/sample_mesh_invalid_file_name.json
@@ -1,0 +1,27 @@
+{
+    "meshConfig":{
+       "sources":[
+          {
+             "name":"<json_source_name>",
+             "handler":{
+                "JsonSchema":{
+                   "baseUrl":"<json_source__baseurl>",
+                   "operations":[
+                      {
+                         "type":"Query",
+                         "field":"<query>",
+                         "path":"<query_path>",
+                         "method":"POST",
+                         "requestSchema":"./requestJSONParameters.json"
+                      }
+                   ]
+                }
+             }
+          }
+       ],
+       "additionalTypeDefs":"<additional_Type_definitions>",
+       "additionalResolvers":[
+          "./additional-resolvers.js"
+       ]
+    }
+  }

--- a/src/commands/__fixtures__/sample_mesh_invalid_paths.json
+++ b/src/commands/__fixtures__/sample_mesh_invalid_paths.json
@@ -1,0 +1,23 @@
+{
+    "meshConfig": {
+      "sources": [
+        {
+          "name": "<json_source_name>",
+          "handler": {
+            "JsonSchema": {
+              "baseUrl": "<json_source__baseurl>",
+              "operations": [
+                {
+                  "type": "Query",
+                  "field": "<query>",
+                  "path": "<query_path>",
+                  "method": "POST",
+                  "requestSchema": "./schemaBody.json"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/src/commands/__fixtures__/sample_mesh_invalid_type.json
+++ b/src/commands/__fixtures__/sample_mesh_invalid_type.json
@@ -1,0 +1,27 @@
+{
+    "meshConfig":{
+       "sources":[
+          {
+             "name":"<json_source_name>",
+             "handler":{
+                "JsonSchema":{
+                   "baseUrl":"<json_source__baseurl>",
+                   "operations":[
+                      {
+                         "type":"Query",
+                         "field":"<query>",
+                         "path":"<query_path>",
+                         "method":"POST",
+                         "requestSchema":"./requestParams.txt"
+                      }
+                   ]
+                }
+             }
+          }
+       ],
+       "additionalTypeDefs":"<additional_Type_definitions>",
+       "additionalResolvers":[
+          "./additional-resolvers.js"
+       ]
+    }
+  }

--- a/src/commands/__fixtures__/sample_mesh_mismatching_path.json
+++ b/src/commands/__fixtures__/sample_mesh_mismatching_path.json
@@ -1,0 +1,29 @@
+{
+    "meshConfig":{
+       "sources":[
+          {
+             "name":"<json_source_name>",
+             "handler":{
+                "JsonSchema":{
+                   "baseUrl":"<json_source__baseurl>",
+                   "operations":[
+                      {
+                         "type":"Query",
+                         "field":"<query>",
+                         "path":"<query_path>",
+                         "method":"POST",
+                         "requestSchema":"./requestParams.json"
+                      }
+                   ]
+                }
+             }
+          }
+       ],
+       "files": [
+        {
+            "path": "./requestPARAMS.json",
+            "content": "{\"type\":\"dummyObject\"}"
+        }
+       ]
+    }
+  }

--- a/src/commands/__fixtures__/sample_mesh_outside_workspace_dir.json
+++ b/src/commands/__fixtures__/sample_mesh_outside_workspace_dir.json
@@ -1,0 +1,23 @@
+{
+    "meshConfig": {
+      "sources": [
+        {
+          "name": "<json_source_name>",
+          "handler": {
+            "JsonSchema": {
+              "baseUrl": "<json_source__baseurl>",
+              "operations": [
+                {
+                  "type": "Query",
+                  "field": "<query>",
+                  "path": "<query_path>",
+                  "method": "POST",
+                  "requestSchema": "../requestParams.json"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/src/commands/__fixtures__/sample_mesh_path_from_home.json
+++ b/src/commands/__fixtures__/sample_mesh_path_from_home.json
@@ -1,0 +1,14 @@
+{
+    "meshConfig":{
+       "sources":[
+          {
+            "name": "CurrencyAPI",
+            "handler": {
+              "openapi": {
+                "source": "~/venia-openapi-schema.json"
+              }
+            }
+          }
+       ]
+    }
+ }

--- a/src/commands/__fixtures__/sample_mesh_subdirectory.json
+++ b/src/commands/__fixtures__/sample_mesh_subdirectory.json
@@ -1,0 +1,23 @@
+{
+    "meshConfig": {
+      "sources": [
+        {
+          "name": "<json_source_name>",
+          "handler": {
+            "JsonSchema": {
+              "baseUrl": "<json_source__baseurl>",
+              "operations": [
+                {
+                  "type": "Query",
+                  "field": "<query>",
+                  "path": "<query_path>",
+                  "method": "POST",
+                  "requestSchema": "./files/requestParams.json"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/src/commands/__fixtures__/sample_mesh_with_files_array.json
+++ b/src/commands/__fixtures__/sample_mesh_with_files_array.json
@@ -1,0 +1,29 @@
+{
+    "meshConfig": {
+      "sources": [
+        {
+          "name": "<json_source_name>",
+          "handler": {
+            "JsonSchema": {
+              "baseUrl": "<json_source__baseurl>",
+              "operations": [
+                {
+                  "type": "Query",
+                  "field": "<query>",
+                  "path": "<query_path>",
+                  "method": "POST",
+                  "requestSchema": "./requestParams.json"
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "files": [
+        {
+          "path": "./requestParams.json",
+          "content": "{\"type\":\"dummyContent\"}"
+        }
+      ]
+    }
+  }

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -1421,4 +1421,31 @@ describe('create command tests', () => {
 		]
 	`);
 	});
+
+	test('should fail if the file path starts from home directory i.e., path starts with ~/', async () => {
+		parseSpy.mockResolvedValue({
+			args: { file: 'src/commands/__fixtures__/sample_mesh_path_from_home.json' },
+			flags: {
+				autoConfirmAction: Promise.resolve(false),
+			},
+		});
+
+		const output = CreateCommand.run();
+
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid.'));
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "File(s): venia-openapi-schema.json is outside the mesh directory.",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Input mesh config is not valid.",
+		  ],
+		]
+	`);
+	});
 });

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -817,12 +817,12 @@ describe('create command tests', () => {
 
 		promptConfirm.mockResolvedValue(false).mockResolvedValue(true);
 
+		importFiles.mockResolvedValue(meshConfig);
+
 		createMesh.mockResolvedValue({
 			meshId: 'dummy_mesh_id',
 			meshConfig: meshConfig,
 		});
-
-		importFiles.mockResolvedValue(meshConfig);
 
 		parseSpy.mockResolvedValue({
 			args: { file: 'src/commands/__fixtures__/sample_mesh_with_files_array.json' },
@@ -957,11 +957,6 @@ describe('create command tests', () => {
 
 		promptConfirm.mockResolvedValue(true).mockResolvedValue(true);
 
-		createMesh.mockResolvedValue({
-			meshId: 'dummy_mesh_id',
-			meshConfig: meshConfig,
-		});
-
 		parseSpy.mockResolvedValue({
 			args: { file: 'src/commands/__fixtures__/sample_mesh_with_files_array.json' },
 			flags: {
@@ -971,6 +966,11 @@ describe('create command tests', () => {
 
 		importFiles.mockResolvedValueOnce({
 			meshConfig,
+		});
+
+		createMesh.mockResolvedValue({
+			meshId: 'dummy_mesh_id',
+			meshConfig: meshConfig,
 		});
 
 		const output = await CreateCommand.run();
@@ -1071,7 +1071,7 @@ describe('create command tests', () => {
 	`);
 	});
 
-	test('should pass for a full-qualified meshConfig even if the file does not exist in fileSystem', async () => {
+	test('should pass for a fully-qualified meshConfig even if the file does not exist in fileSystem', async () => {
 		let meshConfig = {
 			sources: [
 				{
@@ -1109,6 +1109,10 @@ describe('create command tests', () => {
 
 		promptConfirm.mockResolvedValue(true);
 
+		importFiles.mockResolvedValueOnce({
+			meshConfig,
+		});
+
 		createMesh.mockResolvedValue({
 			meshId: 'dummy_mesh_id',
 			meshConfig: meshConfig,
@@ -1123,31 +1127,33 @@ describe('create command tests', () => {
 		  "5678",
 		  "123456789",
 		  {
-		    "files": [
-		      {
-		        "content": "{"type":"dummyContent"}",
-		        "path": "./requestParams.json",
-		      },
-		    ],
-		    "sources": [
-		      {
-		        "handler": {
-		          "JsonSchema": {
-		            "baseUrl": "<json_source__baseurl>",
-		            "operations": [
-		              {
-		                "field": "<query>",
-		                "method": "POST",
-		                "path": "<query_path>",
-		                "requestSchema": "./requestParams.json",
-		                "type": "Query",
-		              },
-		            ],
-		          },
+		    "meshConfig": {
+		      "files": [
+		        {
+		          "content": "{"type":"dummyContent"}",
+		          "path": "./schemaBody.json",
 		        },
-		        "name": "<json_source_name>",
-		      },
-		    ],
+		      ],
+		      "sources": [
+		        {
+		          "handler": {
+		            "JsonSchema": {
+		              "baseUrl": "<json_source__baseurl>",
+		              "operations": [
+		                {
+		                  "field": "<query>",
+		                  "method": "POST",
+		                  "path": "<query_path>",
+		                  "requestSchema": "./schemaBody.json",
+		                  "type": "Query",
+		                },
+		              ],
+		            },
+		          },
+		          "name": "<json_source_name>",
+		        },
+		      ],
+		    },
 		  },
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -14,7 +14,13 @@ const mockConsoleCLIInstance = {};
 
 const CreateCommand = require('../create');
 const sampleCreateMeshConfig = require('../../__fixtures__/sample_mesh.json');
-const { initSdk, initRequestId, promptConfirm } = require('../../../helpers');
+const {
+	initSdk,
+	initRequestId,
+	promptConfirm,
+	getFilesInMeshConfig,
+	importFiles,
+} = require('../../../helpers');
 const {
 	createMesh,
 	createAPIMeshCredentials,
@@ -40,6 +46,8 @@ jest.mock('../../../helpers', () => ({
 	initSdk: jest.fn().mockResolvedValue({}),
 	initRequestId: jest.fn().mockResolvedValue({}),
 	promptConfirm: jest.fn().mockResolvedValue(true),
+	getFilesInMeshConfig: jest.fn().mockReturnValue([]),
+	importFiles: jest.fn().mockResolvedValue(),
 }));
 jest.mock('../../../lib/devConsole');
 
@@ -480,5 +488,622 @@ describe('create command tests', () => {
 		]
 	`);
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+	});
+
+	test('should pass if there are local files in meshConfig i.e., the file is appended in files array', async () => {
+		let meshConfig = {
+			sources: [
+				{
+					name: '<json_source_name>',
+					handler: {
+						JsonSchema: {
+							baseUrl: '<json_source__baseurl>',
+							operations: [
+								{
+									type: 'Query',
+									field: '<query>',
+									path: '<query_path>',
+									method: 'POST',
+									requestSchema: './requestParams.json',
+								},
+							],
+						},
+					},
+				},
+			],
+			files: [
+				{
+					path: './requestParams.json',
+					content: '{"type":"dummyContent"}',
+				},
+			],
+		};
+
+		createMesh.mockResolvedValue({
+			meshId: 'dummy_mesh_id',
+			meshConfig: meshConfig,
+		});
+
+		parseSpy.mockResolvedValue({
+			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
+			flags: {
+				autoConfirmAction: Promise.resolve(false),
+			},
+		});
+
+		getFilesInMeshConfig.mockReturnValue(['./requestParams.json']);
+
+		importFiles.mockResolvedValueOnce({
+			meshConfig,
+		});
+
+		const output = await CreateCommand.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(createMesh.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		  {
+		    "meshConfig": {
+		      "files": [
+		        {
+		          "content": "{"type":"dummyContent"}",
+		          "path": "./requestParams.json",
+		        },
+		      ],
+		      "sources": [
+		        {
+		          "handler": {
+		            "JsonSchema": {
+		              "baseUrl": "<json_source__baseurl>",
+		              "operations": [
+		                {
+		                  "field": "<query>",
+		                  "method": "POST",
+		                  "path": "<query_path>",
+		                  "requestSchema": "./requestParams.json",
+		                  "type": "Query",
+		                },
+		              ],
+		            },
+		          },
+		          "name": "<json_source_name>",
+		        },
+		      ],
+		    },
+		  },
+		]
+	`);
+		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		]
+		`);
+
+		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		  "dummy_id",
+		]
+		`);
+		expect(output).toMatchInlineSnapshot(`
+		{
+		  "adobeIdIntegrationsForWorkspace": {
+		    "apiKey": "dummy_api_key",
+		    "id": "dummy_id",
+		  },
+		  "mesh": {
+		    "meshConfig": {
+		      "files": [
+		        {
+		          "content": "{"type":"dummyContent"}",
+		          "path": "./requestParams.json",
+		        },
+		      ],
+		      "sources": [
+		        {
+		          "handler": {
+		            "JsonSchema": {
+		              "baseUrl": "<json_source__baseurl>",
+		              "operations": [
+		                {
+		                  "field": "<query>",
+		                  "method": "POST",
+		                  "path": "<query_path>",
+		                  "requestSchema": "./requestParams.json",
+		                  "type": "Query",
+		                },
+		              ],
+		            },
+		          },
+		          "name": "<json_source_name>",
+		        },
+		      ],
+		    },
+		    "meshId": "dummy_mesh_id",
+		  },
+		  "sdkList": [
+		    "dummy_service",
+		  ],
+		}
+	`);
+	});
+
+	test('should fail if the file name is more than 25 characters', async () => {
+		parseSpy.mockResolvedValue({
+			args: { file: 'src/commands/__fixtures__/sample_mesh_invalid_file_name.json' },
+			flags: {
+				autoConfirmAction: Promise.resolve(false),
+			},
+		});
+
+		getFilesInMeshConfig.mockImplementation(() => {
+			throw new Error(
+				'Mesh file names must be less than 25 characters. The following file(s) are invalid: requestJSONParameters.json',
+			);
+		});
+
+		const output = CreateCommand.run();
+
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Mesh file names must be less than 25 characters. The following file(s) are invalid: requestJSONParameters.json",
+		  ],
+		]
+	`);
+
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Input mesh config is not valid",
+		  ],
+		]
+	`);
+	});
+
+	test('should fail if the file paths in files array and filenames in sources, transforms, additionalResolvers do not match in mesh config', async () => {
+		parseSpy.mockResolvedValue({
+			args: { file: 'src/commands/__fixtures__/sample_mesh_mismatching_path.json' },
+			flags: {
+				autoConfirmAction: Promise.resolve(false),
+			},
+		});
+
+		getFilesInMeshConfig.mockImplementation(() => {
+			throw new Error(
+				'Please make sure the file requestPaams.json is matching in both places in meshConfig',
+			);
+		});
+
+		const output = CreateCommand.run();
+
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Please make sure the file requestPaams.json is matching in both places in meshConfig",
+		  ],
+		]
+	`);
+
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Input mesh config is not valid",
+		  ],
+		]
+	`);
+	});
+
+	test('should fail if the file is of type other than js, json extension', async () => {
+		parseSpy.mockResolvedValue({
+			args: { file: 'src/commands/__fixtures__/sample_mesh_invalid_type.json' },
+			flags: {
+				autoConfirmAction: Promise.resolve(false),
+			},
+		});
+
+		getFilesInMeshConfig.mockImplementation(() => {
+			throw new Error(
+				'Mesh files must be JavaScript or JSON. Other file types are not supported. The following files are invalid: requestParams.txt',
+			);
+		});
+
+		const output = CreateCommand.run();
+
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Mesh files must be JavaScript or JSON. Other file types are not supported. The following files are invalid: requestParams.txt",
+		  ],
+		]
+	`);
+
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Input mesh config is not valid",
+		  ],
+		]
+	`);
+	});
+
+	test('should fail if the meshConfig and the file are not in the same directory', async () => {
+		parseSpy.mockResolvedValue({
+			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
+			flags: {
+				autoConfirmAction: Promise.resolve(false),
+			},
+		});
+
+		getFilesInMeshConfig.mockImplementation(() => {
+			throw new Error(
+				'Please make sure the files and requestParams.json and sample_mesh_files.json are in the same directory',
+			);
+		});
+
+		const output = CreateCommand.run();
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Please make sure the files and requestParams.json and sample_mesh_files.json are in the same directory",
+		  ],
+		]
+	`);
+
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Input mesh config is not valid",
+		  ],
+		]
+	`);
+	});
+
+	test('should fail if import files function fails', async () => {
+		parseSpy.mockResolvedValue({
+			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
+			flags: {
+				autoConfirmAction: Promise.resolve(false),
+			},
+		});
+
+		getFilesInMeshConfig.mockReturnValue(['./requestParams.json']);
+
+		importFiles.mockImplementation(() => {
+			throw new Error('Error reading the file');
+		});
+
+		const output = CreateCommand.run();
+
+		await expect(output).rejects.toEqual(
+			new Error(
+				'Unable to import the files in the mesh config. Please check the file and try again.',
+			),
+		);
+
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Error reading the file",
+		  ],
+		]
+	`);
+
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Unable to import the files in the mesh config. Please check the file and try again.",
+		  ],
+		]
+	`);
+	});
+
+	test('should not override if prompt returns No, if there is files array', async () => {
+		let meshConfig = {
+			sources: [
+				{
+					name: '<json_source_name>',
+					handler: {
+						JsonSchema: {
+							baseUrl: '<json_source__baseurl>',
+							operations: [
+								{
+									type: 'Query',
+									field: '<query>',
+									path: '<query_path>',
+									method: 'POST',
+									requestSchema: './requestParams.json',
+								},
+							],
+						},
+					},
+				},
+			],
+			files: [
+				{
+					path: './requestParams.json',
+					content: '{"type":"dummyContent"}',
+				},
+			],
+		};
+
+		promptConfirm.mockResolvedValue(false).mockResolvedValue(true);
+
+		createMesh.mockResolvedValue({
+			meshId: 'dummy_mesh_id',
+			meshConfig: meshConfig,
+		});
+
+		parseSpy.mockResolvedValue({
+			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
+			flags: {
+				autoConfirmAction: Promise.resolve(false),
+			},
+		});
+
+		getFilesInMeshConfig.mockReturnValue(['./requestParams.json']);
+
+		importFiles.mockResolvedValueOnce({
+			meshConfig,
+		});
+
+		const output = await CreateCommand.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(createMesh.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		  {
+		    "meshConfig": {
+		      "files": [
+		        {
+		          "content": "{"type":"dummyContent"}",
+		          "path": "./requestParams.json",
+		        },
+		      ],
+		      "sources": [
+		        {
+		          "handler": {
+		            "JsonSchema": {
+		              "baseUrl": "<json_source__baseurl>",
+		              "operations": [
+		                {
+		                  "field": "<query>",
+		                  "method": "POST",
+		                  "path": "<query_path>",
+		                  "requestSchema": "./requestParams.json",
+		                  "type": "Query",
+		                },
+		              ],
+		            },
+		          },
+		          "name": "<json_source_name>",
+		        },
+		      ],
+		    },
+		  },
+		]
+	`);
+		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		]
+	`);
+
+		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		  "dummy_id",
+		]
+	`);
+		expect(output).toMatchInlineSnapshot(`
+		{
+		  "adobeIdIntegrationsForWorkspace": {
+		    "apiKey": "dummy_api_key",
+		    "id": "dummy_id",
+		  },
+		  "mesh": {
+		    "meshConfig": {
+		      "files": [
+		        {
+		          "content": "{"type":"dummyContent"}",
+		          "path": "./requestParams.json",
+		        },
+		      ],
+		      "sources": [
+		        {
+		          "handler": {
+		            "JsonSchema": {
+		              "baseUrl": "<json_source__baseurl>",
+		              "operations": [
+		                {
+		                  "field": "<query>",
+		                  "method": "POST",
+		                  "path": "<query_path>",
+		                  "requestSchema": "./requestParams.json",
+		                  "type": "Query",
+		                },
+		              ],
+		            },
+		          },
+		          "name": "<json_source_name>",
+		        },
+		      ],
+		    },
+		    "meshId": "dummy_mesh_id",
+		  },
+		  "sdkList": [
+		    "dummy_service",
+		  ],
+		}
+	`);
+	});
+
+	test('should override if prompt returns Yes, if there is files array', async () => {
+		let meshConfig = {
+			sources: [
+				{
+					name: '<json_source_name>',
+					handler: {
+						JsonSchema: {
+							baseUrl: '<json_source__baseurl>',
+							operations: [
+								{
+									type: 'Query',
+									field: '<query>',
+									path: '<query_path>',
+									method: 'POST',
+									requestSchema: './requestParams.json',
+								},
+							],
+						},
+					},
+				},
+			],
+			files: [
+				{
+					path: './requestParams.json',
+					content: '{"type":"updatedContent"}',
+				},
+			],
+		};
+
+		promptConfirm.mockResolvedValue(true).mockResolvedValue(true);
+
+		createMesh.mockResolvedValue({
+			meshId: 'dummy_mesh_id',
+			meshConfig: meshConfig,
+		});
+
+		parseSpy.mockResolvedValue({
+			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
+			flags: {
+				autoConfirmAction: Promise.resolve(false),
+			},
+		});
+
+		getFilesInMeshConfig.mockReturnValue(['./requestParams.json']);
+
+		importFiles.mockResolvedValueOnce({
+			meshConfig,
+		});
+
+		const output = await CreateCommand.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(createMesh.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		  {
+		    "meshConfig": {
+		      "files": [
+		        {
+		          "content": "{"type":"updatedContent"}",
+		          "path": "./requestParams.json",
+		        },
+		      ],
+		      "sources": [
+		        {
+		          "handler": {
+		            "JsonSchema": {
+		              "baseUrl": "<json_source__baseurl>",
+		              "operations": [
+		                {
+		                  "field": "<query>",
+		                  "method": "POST",
+		                  "path": "<query_path>",
+		                  "requestSchema": "./requestParams.json",
+		                  "type": "Query",
+		                },
+		              ],
+		            },
+		          },
+		          "name": "<json_source_name>",
+		        },
+		      ],
+		    },
+		  },
+		]
+	`);
+		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		]
+	`);
+
+		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		  "dummy_id",
+		]
+	`);
+		expect(output).toMatchInlineSnapshot(`
+		{
+		  "adobeIdIntegrationsForWorkspace": {
+		    "apiKey": "dummy_api_key",
+		    "id": "dummy_id",
+		  },
+		  "mesh": {
+		    "meshConfig": {
+		      "files": [
+		        {
+		          "content": "{"type":"updatedContent"}",
+		          "path": "./requestParams.json",
+		        },
+		      ],
+		      "sources": [
+		        {
+		          "handler": {
+		            "JsonSchema": {
+		              "baseUrl": "<json_source__baseurl>",
+		              "operations": [
+		                {
+		                  "field": "<query>",
+		                  "method": "POST",
+		                  "path": "<query_path>",
+		                  "requestSchema": "./requestParams.json",
+		                  "type": "Query",
+		                },
+		              ],
+		            },
+		          },
+		          "name": "<json_source_name>",
+		        },
+		      ],
+		    },
+		    "meshId": "dummy_mesh_id",
+		  },
+		  "sdkList": [
+		    "dummy_service",
+		  ],
+		}
+	`);
 	});
 });

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -14,13 +14,7 @@ const mockConsoleCLIInstance = {};
 
 const CreateCommand = require('../create');
 const sampleCreateMeshConfig = require('../../__fixtures__/sample_mesh.json');
-const {
-	initSdk,
-	initRequestId,
-	promptConfirm,
-	getFilesInMeshConfig,
-	importFiles,
-} = require('../../../helpers');
+const { initSdk, initRequestId, promptConfirm, importFiles } = require('../../../helpers');
 const {
 	createMesh,
 	createAPIMeshCredentials,
@@ -46,7 +40,6 @@ jest.mock('../../../helpers', () => ({
 	initSdk: jest.fn().mockResolvedValue({}),
 	initRequestId: jest.fn().mockResolvedValue({}),
 	promptConfirm: jest.fn().mockResolvedValue(true),
-	getFilesInMeshConfig: jest.fn().mockReturnValue([]),
 	importFiles: jest.fn().mockResolvedValue(),
 }));
 jest.mock('../../../lib/devConsole');
@@ -514,7 +507,7 @@ describe('create command tests', () => {
 			files: [
 				{
 					path: './requestParams.json',
-					content: '{"type":"dummyContent"}',
+					content: '{"type":"updatedContent"}',
 				},
 			],
 		};
@@ -530,8 +523,6 @@ describe('create command tests', () => {
 				autoConfirmAction: Promise.resolve(false),
 			},
 		});
-
-		getFilesInMeshConfig.mockReturnValue(['./requestParams.json']);
 
 		importFiles.mockResolvedValueOnce({
 			meshConfig,
@@ -549,7 +540,7 @@ describe('create command tests', () => {
 		    "meshConfig": {
 		      "files": [
 		        {
-		          "content": "{"type":"dummyContent"}",
+		          "content": "{"type":"updatedContent"}",
 		          "path": "./requestParams.json",
 		        },
 		      ],
@@ -602,7 +593,7 @@ describe('create command tests', () => {
 		    "meshConfig": {
 		      "files": [
 		        {
-		          "content": "{"type":"dummyContent"}",
+		          "content": "{"type":"updatedContent"}",
 		          "path": "./requestParams.json",
 		        },
 		      ],
@@ -643,20 +634,14 @@ describe('create command tests', () => {
 			},
 		});
 
-		getFilesInMeshConfig.mockImplementation(() => {
-			throw new Error(
-				'Mesh file names must be less than 25 characters. The following file(s) are invalid: requestJSONParameters.json',
-			);
-		});
-
 		const output = CreateCommand.run();
 
-		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid.'));
 
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Mesh file names must be less than 25 characters. The following file(s) are invalid: requestJSONParameters.json",
+		    "Mesh file names must be less than 25 characters. The following file(s) are invalid: requestJSONParameters.json.",
 		  ],
 		]
 	`);
@@ -664,7 +649,7 @@ describe('create command tests', () => {
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Input mesh config is not valid",
+		    "Input mesh config is not valid.",
 		  ],
 		]
 	`);
@@ -678,26 +663,21 @@ describe('create command tests', () => {
 			},
 		});
 
-		getFilesInMeshConfig.mockImplementation(() => {
-			throw new Error('Please make sure the file names are matching in both places in meshConfig');
-		});
-
 		const output = CreateCommand.run();
 
-		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid.'));
 
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Please make sure the file names are matching in both places in meshConfig",
+		    "Please make sure the file names are matching in both places in meshConfig.",
 		  ],
 		]
 	`);
-
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Input mesh config is not valid",
+		    "Input mesh config is not valid.",
 		  ],
 		]
 	`);
@@ -711,28 +691,21 @@ describe('create command tests', () => {
 			},
 		});
 
-		getFilesInMeshConfig.mockImplementation(() => {
-			throw new Error(
-				'Mesh files must be JavaScript or JSON. Other file types are not supported. The following files are invalid: requestParams.txt',
-			);
-		});
-
 		const output = CreateCommand.run();
 
-		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid.'));
 
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Mesh files must be JavaScript or JSON. Other file types are not supported. The following files are invalid: requestParams.txt",
+		    "Mesh files must be JavaScript or JSON. Other file types are not supported. The following file(s) are invalid: requestParams.txt.",
 		  ],
 		]
 	`);
-
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Input mesh config is not valid",
+		    "Input mesh config is not valid.",
 		  ],
 		]
 	`);
@@ -740,25 +713,19 @@ describe('create command tests', () => {
 
 	test('should fail if the meshConfig and the file are not in the same directory', async () => {
 		parseSpy.mockResolvedValue({
-			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
+			args: { file: 'src/commands/__fixtures__/sample_mesh_invalid_paths.json' },
 			flags: {
 				autoConfirmAction: Promise.resolve(false),
 			},
 		});
 
-		getFilesInMeshConfig.mockImplementation(() => {
-			throw new Error(
-				'Please make sure the files and requestParams.json and sample_mesh_files.json are in the same directory',
-			);
-		});
-
 		const output = CreateCommand.run();
-		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid.'));
 
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Please make sure the files and requestParams.json and sample_mesh_files.json are in the same directory",
+		    "Please make sure the files schemaBody.json and sample_mesh_invalid_paths.json are in the same directory.",
 		  ],
 		]
 	`);
@@ -766,7 +733,7 @@ describe('create command tests', () => {
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Input mesh config is not valid",
+		    "Input mesh config is not valid.",
 		  ],
 		]
 	`);
@@ -779,8 +746,6 @@ describe('create command tests', () => {
 				autoConfirmAction: Promise.resolve(false),
 			},
 		});
-
-		getFilesInMeshConfig.mockReturnValue(['./requestParams.json']);
 
 		importFiles.mockImplementation(() => {
 			throw new Error('Error reading the file');
@@ -847,17 +812,13 @@ describe('create command tests', () => {
 			meshConfig: meshConfig,
 		});
 
+		importFiles.mockResolvedValue(meshConfig);
+
 		parseSpy.mockResolvedValue({
-			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
+			args: { file: 'src/commands/__fixtures__/sample_mesh_with_files_array.json' },
 			flags: {
 				autoConfirmAction: Promise.resolve(false),
 			},
-		});
-
-		getFilesInMeshConfig.mockReturnValue(['./requestParams.json']);
-
-		importFiles.mockResolvedValueOnce({
-			meshConfig,
 		});
 
 		const output = await CreateCommand.run();
@@ -869,33 +830,31 @@ describe('create command tests', () => {
 		  "5678",
 		  "123456789",
 		  {
-		    "meshConfig": {
-		      "files": [
-		        {
-		          "content": "{"type":"dummyContent"}",
-		          "path": "./requestParams.json",
-		        },
-		      ],
-		      "sources": [
-		        {
-		          "handler": {
-		            "JsonSchema": {
-		              "baseUrl": "<json_source__baseurl>",
-		              "operations": [
-		                {
-		                  "field": "<query>",
-		                  "method": "POST",
-		                  "path": "<query_path>",
-		                  "requestSchema": "./requestParams.json",
-		                  "type": "Query",
-		                },
-		              ],
-		            },
+		    "files": [
+		      {
+		        "content": "{"type":"dummyContent"}",
+		        "path": "./requestParams.json",
+		      },
+		    ],
+		    "sources": [
+		      {
+		        "handler": {
+		          "JsonSchema": {
+		            "baseUrl": "<json_source__baseurl>",
+		            "operations": [
+		              {
+		                "field": "<query>",
+		                "method": "POST",
+		                "path": "<query_path>",
+		                "requestSchema": "./requestParams.json",
+		                "type": "Query",
+		              },
+		            ],
 		          },
-		          "name": "<json_source_name>",
 		        },
-		      ],
-		    },
+		        "name": "<json_source_name>",
+		      },
+		    ],
 		  },
 		]
 	`);
@@ -906,7 +865,6 @@ describe('create command tests', () => {
 		  "123456789",
 		]
 	`);
-
 		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
 		[
 		  "1234",
@@ -995,13 +953,11 @@ describe('create command tests', () => {
 		});
 
 		parseSpy.mockResolvedValue({
-			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
+			args: { file: 'src/commands/__fixtures__/sample_mesh_with_files_array.json' },
 			flags: {
 				autoConfirmAction: Promise.resolve(false),
 			},
 		});
-
-		getFilesInMeshConfig.mockReturnValue(['./requestParams.json']);
 
 		importFiles.mockResolvedValueOnce({
 			meshConfig,

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -679,9 +679,7 @@ describe('create command tests', () => {
 		});
 
 		getFilesInMeshConfig.mockImplementation(() => {
-			throw new Error(
-				'Please make sure the file requestPaams.json is matching in both places in meshConfig',
-			);
+			throw new Error('Please make sure the file names are matching in both places in meshConfig');
 		});
 
 		const output = CreateCommand.run();
@@ -691,7 +689,7 @@ describe('create command tests', () => {
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Please make sure the file requestPaams.json is matching in both places in meshConfig",
+		    "Please make sure the file names are matching in both places in meshConfig",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -721,7 +721,7 @@ describe('create command tests', () => {
 
 		importFiles.mockImplementation(() => {
 			throw new Error(
-				'Please make sure the file(s): schemaBody.json and sample_mesh_invalid_paths.json are in the same directory.',
+				'Please make sure the files: schemaBody.json and sample_mesh_invalid_paths.json are in the same directory.',
 			);
 		});
 
@@ -735,7 +735,7 @@ describe('create command tests', () => {
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Please make sure the file(s): schemaBody.json and sample_mesh_invalid_paths.json are in the same directory.",
+		    "Please make sure the files: schemaBody.json and sample_mesh_invalid_paths.json are in the same directory.",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/update.test.js
+++ b/src/commands/api-mesh/__tests__/update.test.js
@@ -17,7 +17,6 @@ jest.mock('../../../helpers', () => ({
 	initSdk: jest.fn().mockResolvedValue({}),
 	initRequestId: jest.fn().mockResolvedValue({}),
 	promptConfirm: jest.fn().mockResolvedValue(true),
-	getFilesInMeshConfig: jest.fn().mockReturnValue([]),
 	importFiles: jest.fn().mockResolvedValue(),
 }));
 jest.mock('@adobe/aio-cli-lib-console', () => ({
@@ -36,13 +35,7 @@ const selectedWorkspace = { id: '123456789', title: 'Workspace01' };
 const { readFile } = require('fs/promises');
 
 const UpdateCommand = require('../update');
-const {
-	initSdk,
-	initRequestId,
-	promptConfirm,
-	getFilesInMeshConfig,
-	importFiles,
-} = require('../../../helpers');
+const { initSdk, initRequestId, promptConfirm, importFiles } = require('../../../helpers');
 const { getMeshId, updateMesh } = require('../../../lib/devConsole');
 
 let logSpy = null;
@@ -82,6 +75,30 @@ describe('update command tests', () => {
 	});
 
 	test('should pass with valid args', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<api_name>',
+						handler: {
+							graphql: {
+								endpoint: '<gql_endpoint>',
+							},
+						},
+					},
+				],
+			},
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
+
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
+			},
+		});
+
 		const runResult = await UpdateCommand.run();
 
 		expect(runResult).toMatchInlineSnapshot(`
@@ -117,8 +134,24 @@ describe('update command tests', () => {
 	});
 
 	test('should pass with valid args and ignoreCache flag', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<api_name>',
+						handler: {
+							graphql: {
+								endpoint: '<gql_endpoint>',
+							},
+						},
+					},
+				],
+			},
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
+
 		parseSpy.mockResolvedValueOnce({
-			args: { file: 'valid_file_name' },
+			args: { file: 'src/commands/__fixtures__/sample_mesh.json' },
 			flags: {
 				ignoreCache: Promise.resolve(true),
 				autoConfirmAction: mockAutoApproveAction,
@@ -160,8 +193,24 @@ describe('update command tests', () => {
 	});
 
 	test('should pass with valid args if autoConfirmAction flag is set', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<api_name>',
+						handler: {
+							graphql: {
+								endpoint: '<gql_endpoint>',
+							},
+						},
+					},
+				],
+			},
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
+
 		parseSpy.mockResolvedValueOnce({
-			args: { file: 'valid_file_name' },
+			args: { file: 'src/commands/__fixtures__/sample_mesh.json' },
 			flags: {
 				ignoreCache: mockIgnoreCacheFlag,
 				autoConfirmAction: Promise.resolve(true),
@@ -204,6 +253,30 @@ describe('update command tests', () => {
 	});
 
 	test('should fail if mesh id is missing', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<api_name>',
+						handler: {
+							graphql: {
+								endpoint: '<gql_endpoint>',
+							},
+						},
+					},
+				],
+			},
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
+
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
+			},
+		});
+
 		getMeshId.mockResolvedValue(null);
 		const runResult = UpdateCommand.run();
 
@@ -221,6 +294,30 @@ describe('update command tests', () => {
 	});
 
 	test('should fail if getMeshId api failed', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<api_name>',
+						handler: {
+							graphql: {
+								endpoint: '<gql_endpoint>',
+							},
+						},
+					},
+				],
+			},
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
+
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
+			},
+		});
+
 		getMeshId.mockRejectedValue(new Error('getMeshId api failed'));
 		const runResult = UpdateCommand.run();
 
@@ -238,6 +335,30 @@ describe('update command tests', () => {
 	});
 
 	test('should fail if updateMesh method failed', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<api_name>',
+						handler: {
+							graphql: {
+								endpoint: '<gql_endpoint>',
+							},
+						},
+					},
+				],
+			},
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
+
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
+			},
+		});
+
 		updateMesh.mockRejectedValueOnce(new Error('dummy_error'));
 
 		const runResult = UpdateCommand.run();
@@ -316,6 +437,30 @@ describe('update command tests', () => {
 	});
 
 	test('should not update if user prompt returns false', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<api_name>',
+						handler: {
+							graphql: {
+								endpoint: '<gql_endpoint>',
+							},
+						},
+					},
+				],
+			},
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
+
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
+			},
+		});
+
 		promptConfirm.mockResolvedValueOnce(false);
 
 		const runResult = await UpdateCommand.run();
@@ -332,6 +477,31 @@ describe('update command tests', () => {
 	});
 
 	test('should pass if there are local files in meshConfig i.e., the file is appended in files array', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<json_source_name>',
+						handler: {
+							JsonSchema: {
+								baseUrl: '<json_source__baseurl>',
+								operations: [
+									{
+										type: 'Query',
+										field: '<query>',
+										path: '<query_path>',
+										method: 'POST',
+										requestSchema: './requestParams.json',
+									},
+								],
+							},
+						},
+					},
+				],
+			},
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
+
 		let meshConfig = {
 			sources: [
 				{
@@ -355,7 +525,7 @@ describe('update command tests', () => {
 			files: [
 				{
 					path: './requestParams.json',
-					content: '{"type":"dummyContent"}',
+					content: '{"type":"updatedContent"}',
 				},
 			],
 		};
@@ -368,11 +538,9 @@ describe('update command tests', () => {
 		parseSpy.mockResolvedValue({
 			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
 			flags: {
-				autoConfirmAction: Promise.resolve(false),
+				autoConfirmAction: mockAutoApproveAction,
 			},
 		});
-
-		getFilesInMeshConfig.mockReturnValue(['./requestParams.json']);
 
 		importFiles.mockResolvedValueOnce({
 			meshConfig,
@@ -391,7 +559,7 @@ describe('update command tests', () => {
 		    "meshConfig": {
 		      "files": [
 		        {
-		          "content": "{"type":"dummyContent"}",
+		          "content": "{"type":"updatedContent"}",
 		          "path": "./requestParams.json",
 		        },
 		      ],
@@ -418,12 +586,13 @@ describe('update command tests', () => {
 		  },
 		]
 	`);
+
 		expect(output).toMatchInlineSnapshot(`
 		{
 		  "meshConfig": {
 		    "files": [
 		      {
-		        "content": "{"type":"dummyContent"}",
+		        "content": "{"type":"updatedContent"}",
 		        "path": "./requestParams.json",
 		      },
 		    ],
@@ -452,28 +621,48 @@ describe('update command tests', () => {
 	`);
 	});
 
-	test('should fail if the file name is more than 25 characters', async () => {
+	test('should fail if the input mesh config file is inavlid i.e., file name has more than 25 characters', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<json_source_name>',
+						handler: {
+							JsonSchema: {
+								baseUrl: '<json_source__baseurl>',
+								operations: [
+									{
+										type: 'Query',
+										field: '<query>',
+										path: '<query_path>',
+										method: 'POST',
+										requestSchema: './requestJSONParameters.json',
+									},
+								],
+							},
+						},
+					},
+				],
+			},
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
+
 		parseSpy.mockResolvedValue({
 			args: { file: 'src/commands/__fixtures__/sample_mesh_invalid_file_name.json' },
 			flags: {
-				autoConfirmAction: Promise.resolve(false),
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
 			},
-		});
-
-		getFilesInMeshConfig.mockImplementation(() => {
-			throw new Error(
-				'Mesh file names must be less than 25 characters. The following file(s) are invalid: requestJSONParameters.json',
-			);
 		});
 
 		const output = UpdateCommand.run();
 
-		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid.'));
 
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Mesh file names must be less than 25 characters. The following file(s) are invalid: requestJSONParameters.json",
+		    "Mesh file names must be less than 25 characters. The following file(s) are invalid: requestJSONParameters.json.",
 		  ],
 		]
 	`);
@@ -481,101 +670,61 @@ describe('update command tests', () => {
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Input mesh config is not valid",
+		    "Input mesh config is not valid.",
 		  ],
 		]
 	`);
 	});
 
-	test('should fail if the file paths in files array and filenames in sources, transforms, additionalResolvers do not match in mesh config', async () => {
-		parseSpy.mockResolvedValue({
-			args: { file: 'src/commands/__fixtures__/sample_mesh_mismatching_path.json' },
-			flags: {
-				autoConfirmAction: Promise.resolve(false),
+	test('should fail if the import files function fails', async () => {
+		let sampleMesh = {
+			meshConfig: {
+				sources: [
+					{
+						name: '<json_source_name>',
+						handler: {
+							JsonSchema: {
+								baseUrl: '<json_source__baseurl>',
+								operations: [
+									{
+										type: 'Query',
+										field: '<query>',
+										path: '<query_path>',
+										method: 'POST',
+										requestSchema: './requestParams.json',
+									},
+								],
+							},
+						},
+					},
+				],
 			},
-		});
+		};
+		readFile.mockResolvedValue(JSON.stringify(sampleMesh));
 
-		getFilesInMeshConfig.mockImplementation(() => {
-			throw new Error('Please make sure the file names are matching in both places in meshConfig');
-		});
-
-		const output = UpdateCommand.run();
-
-		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
-
-		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
-		[
-		  [
-		    "Please make sure the file names are matching in both places in meshConfig",
-		  ],
-		]
-	`);
-
-		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
-		[
-		  [
-		    "Input mesh config is not valid",
-		  ],
-		]
-	`);
-	});
-
-	test('should fail if the file is of type other than js, json extension', async () => {
-		parseSpy.mockResolvedValue({
-			args: { file: 'src/commands/__fixtures__/sample_mesh_invalid_type.json' },
-			flags: {
-				autoConfirmAction: Promise.resolve(false),
-			},
-		});
-
-		getFilesInMeshConfig.mockImplementation(() => {
-			throw new Error(
-				'Mesh files must be JavaScript or JSON. Other file types are not supported. The following files are invalid: requestParams.txt',
-			);
-		});
-
-		const output = UpdateCommand.run();
-
-		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
-
-		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
-		[
-		  [
-		    "Mesh files must be JavaScript or JSON. Other file types are not supported. The following files are invalid: requestParams.txt",
-		  ],
-		]
-	`);
-
-		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
-		[
-		  [
-		    "Input mesh config is not valid",
-		  ],
-		]
-	`);
-	});
-
-	test('should fail if the meshConfig and the file are not in the same directory', async () => {
 		parseSpy.mockResolvedValue({
 			args: { file: 'src/commands/__fixtures__/sample_mesh_files.json' },
 			flags: {
-				autoConfirmAction: Promise.resolve(false),
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
 			},
 		});
 
-		getFilesInMeshConfig.mockImplementation(() => {
-			throw new Error(
-				'Please make sure the files and requestParams.json and sample_mesh_files.json are in the same directory',
-			);
+		importFiles.mockImplementation(() => {
+			throw new Error('Error reading the file.');
 		});
 
 		const output = UpdateCommand.run();
-		await expect(output).rejects.toEqual(new Error('Input mesh config is not valid'));
+		await expect(output).rejects.toEqual(
+			new Error(
+				'Unable to import the files in the mesh config. Please check the file and try again.',
+			),
+		);
 
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Please make sure the files and requestParams.json and sample_mesh_files.json are in the same directory",
+		    "Error reading the file.",
 		  ],
 		]
 	`);
@@ -583,7 +732,7 @@ describe('update command tests', () => {
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Input mesh config is not valid",
+		    "Unable to import the files in the mesh config. Please check the file and try again.",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -12,16 +12,15 @@ governing permissions and limitations under the License.
 const { Command } = require('@oclif/core');
 const { readFile } = require('fs/promises');
 
-const {
-	initSdk,
-	initRequestId,
-	promptConfirm,
-	getFilesInMeshConfig,
-	importFiles,
-} = require('../../helpers');
+const { initSdk, initRequestId, promptConfirm, importFiles } = require('../../helpers');
 const logger = require('../../classes/logger');
 const CONSTANTS = require('../../constants');
-const { ignoreCacheFlag, autoConfirmActionFlag, jsonFlag } = require('../../utils');
+const {
+	ignoreCacheFlag,
+	autoConfirmActionFlag,
+	jsonFlag,
+	getFilesInMeshConfig,
+} = require('../../utils');
 const {
 	createMesh,
 	createAPIMeshCredentials,
@@ -81,7 +80,7 @@ class CreateCommand extends Command {
 			filesList = getFilesInMeshConfig(data, args.file);
 		} catch (err) {
 			this.log(err.message);
-			this.error('Input mesh config is not valid');
+			this.error('Input mesh config is not valid.');
 		}
 
 		// if local files are present, import them in files array in meshConfig

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -66,22 +66,34 @@ class CreateCommand extends Command {
 
 		try {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
-
-			let filesList = [];
-			filesList = getFilesInMeshConfig(data, args.file);
-	
-			// if local files are present, import them in files array in meshConfig
-			if (filesList.length) {
-				await importFiles(data, filesList, args.file, flags.autoConfirmAction);
-			}
 		} catch (error) {
 			logger.error(error);
 
 			this.log(error.message);
-			// this.log(`ENOENT: no such file or directory, open \'${args.file}\'`);
 			this.error(
 				'Unable to read the mesh configuration file provided. Please check the file and try again.',
 			);
+		}
+
+		let filesList = [];
+
+		try {
+			filesList = getFilesInMeshConfig(data, args.file);
+		} catch (err) {
+			this.log(err.message);
+			this.error('Input mesh config is not valid');
+		}
+
+		// if local files are present, import them in files array in meshConfig
+		if (filesList.length) {
+			try {
+				data = await importFiles(data, filesList, args.file, flags.autoConfirmAction);
+			} catch (err) {
+				this.log(err.message);
+				this.error(
+					'Unable to import the files in the mesh config. Please check the file and try again.',
+				);
+			}
 		}
 
 		let shouldContinue = true;

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -77,7 +77,7 @@ class CreateCommand extends Command {
 		let filesList = [];
 
 		try {
-			filesList = getFilesInMeshConfig(data, args.file);
+			filesList = getFilesInMeshConfig(data);
 		} catch (err) {
 			this.log(err.message);
 			this.error('Input mesh config is not valid.');

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -77,7 +77,7 @@ class CreateCommand extends Command {
 		let filesList = [];
 
 		try {
-			filesList = getFilesInMeshConfig(data);
+			filesList = getFilesInMeshConfig(data, args.file);
 		} catch (err) {
 			this.log(err.message);
 			this.error('Input mesh config is not valid.');

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -67,8 +67,9 @@ class CreateCommand extends Command {
 		try {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
 
-			const filesList = getFilesInMeshConfig(data, args.file);
-			// console.log(filesList);
+			let filesList = [];
+			filesList = getFilesInMeshConfig(data, args.file);
+	
 			// if local files are present, import them in files array in meshConfig
 			if (filesList.length) {
 				await importFiles(data, filesList, args.file, flags.autoConfirmAction);

--- a/src/commands/api-mesh/update.js
+++ b/src/commands/api-mesh/update.js
@@ -56,13 +56,6 @@ class UpdateCommand extends Command {
 
 		try {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
-
-			const filesList = getFilesInMeshConfig(data, args.file);
-
-			//if local files are present, import them in files array in meshConfig
-			if (filesList) {
-				await importFiles(data, filesList, args.file, flags.autoConfirmAction);
-			}
 		} catch (error) {
 			logger.error(error);
 
@@ -70,6 +63,27 @@ class UpdateCommand extends Command {
 			this.error(
 				'Unable to read the mesh configuration file provided. Please check the file and try again.',
 			);
+		}
+
+		let filesList = [];
+
+		try {
+			filesList = getFilesInMeshConfig(data, args.file);
+		} catch (err) {
+			this.log(err.message);
+			this.error('Input mesh config is not valid');
+		}
+
+		// if local files are present, import them in files array in meshConfig
+		if (filesList.length) {
+			try {
+				data = await importFiles(data, filesList, args.file, flags.autoConfirmAction);
+			} catch (err) {
+				this.log(err.message);
+				this.error(
+					'Unable to import the files in the mesh config. Please check the file and try again.',
+				);
+			}
 		}
 
 		let meshId = null;

--- a/src/commands/api-mesh/update.js
+++ b/src/commands/api-mesh/update.js
@@ -13,7 +13,13 @@ const { Command } = require('@oclif/command');
 const { readFile } = require('fs/promises');
 
 const logger = require('../../classes/logger');
-const { initSdk, initRequestId, promptConfirm } = require('../../helpers');
+const {
+	initSdk,
+	initRequestId,
+	promptConfirm,
+	getFilesInMeshConfig,
+	importFiles,
+} = require('../../helpers');
 const { ignoreCacheFlag, autoConfirmActionFlag } = require('../../utils');
 const { getMeshId, updateMesh } = require('../../lib/devConsole');
 
@@ -50,6 +56,13 @@ class UpdateCommand extends Command {
 
 		try {
 			data = JSON.parse(await readFile(args.file, 'utf8'));
+
+			const filesList = getFilesInMeshConfig(data, args.file);
+
+			//if local files are present, import them in files array in meshConfig
+			if (filesList) {
+				await importFiles(data, filesList, args.file, flags.autoConfirmAction);
+			}
 		} catch (error) {
 			logger.error(error);
 

--- a/src/commands/api-mesh/update.js
+++ b/src/commands/api-mesh/update.js
@@ -13,14 +13,8 @@ const { Command } = require('@oclif/command');
 const { readFile } = require('fs/promises');
 
 const logger = require('../../classes/logger');
-const {
-	initSdk,
-	initRequestId,
-	promptConfirm,
-	getFilesInMeshConfig,
-	importFiles,
-} = require('../../helpers');
-const { ignoreCacheFlag, autoConfirmActionFlag } = require('../../utils');
+const { initSdk, initRequestId, promptConfirm, importFiles } = require('../../helpers');
+const { ignoreCacheFlag, autoConfirmActionFlag, getFilesInMeshConfig } = require('../../utils');
 const { getMeshId, updateMesh } = require('../../lib/devConsole');
 
 require('dotenv').config();
@@ -71,7 +65,7 @@ class UpdateCommand extends Command {
 			filesList = getFilesInMeshConfig(data, args.file);
 		} catch (err) {
 			this.log(err.message);
-			this.error('Input mesh config is not valid');
+			this.error('Input mesh config is not valid.');
 		}
 
 		// if local files are present, import them in files array in meshConfig

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -520,12 +520,11 @@ function getFilesInMeshConfig(data, meshConfigName) {
 		});
 	});
 
-	if (filesList) {
+	if (filesList.length) {
 		validateFileName(filesList, data);
 		validateFilePaths(filesList, meshConfigName);
 		validateFileType(filesList);
 	}
-	// console.log('sdvdfb');
 
 	return filesList;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -498,13 +498,13 @@ async function importFiles(data, filesListArray, meshConfigName, autoConfirmActi
 
 				if (shouldOverride) {
 					let index = filesPathMap.get(file);
-					resultData = updateFilesArray(data, file, meshConfigName, index);
+					resultData = updateFilesArray(resultData, file, meshConfigName, index);
 				}
 			}
 		} else {
 			//if file does not exist in files array, but exists in filesystem, we append
 			if (fs.existsSync(path.resolve(path.dirname(meshConfigName), file))) {
-				resultData = updateFilesArray(data, file, meshConfigName, -1);
+				resultData = updateFilesArray(resultData, file, meshConfigName, -1);
 			} else {
 				filesNotFound.push(file);
 			}
@@ -517,7 +517,7 @@ async function importFiles(data, filesListArray, meshConfigName, autoConfirmActi
 		}
 
 		throw new Error(
-			`Please make sure the files: ${filesNotFound.join(', ')} and ${path.basename(
+			`Please make sure the file(s): ${filesNotFound.join(', ')} and ${path.basename(
 				meshConfigName,
 			)} are in the same directory`,
 		);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -477,7 +477,12 @@ async function importFiles(data, filesListArray, meshConfigName, autoConfirmActi
 			return [ele];
 		}),
 	);
+
+	//copy the meshConfig data
 	let resultData = data;
+
+	//array of {file to be overridden, overrideIndex}
+	let overrideArr = [];
 
 	if (data.meshConfig.files) {
 		for (let i = 0; i < data.meshConfig.files?.length; i++) {
@@ -491,14 +496,8 @@ async function importFiles(data, filesListArray, meshConfigName, autoConfirmActi
 			//if file exists in files array, then override
 			if (fs.existsSync(path.resolve(path.dirname(meshConfigName), file))) {
 				if (!autoConfirmActionFlag) {
-					shouldOverride = await promptConfirm(
-						`Do you want to override the ${path.basename(file)} file?`,
-					);
-				}
-
-				if (shouldOverride) {
 					let index = filesPathMap.get(file);
-					resultData = updateFilesArray(resultData, file, meshConfigName, index);
+					overrideArr.push({ fileName: file, index: index });
 				}
 			}
 		} else {
@@ -521,6 +520,21 @@ async function importFiles(data, filesListArray, meshConfigName, autoConfirmActi
 				meshConfigName,
 			)} are in the same directory`,
 		);
+	}
+
+	for (let i = 0; i < overrideArr.length; i++) {
+		shouldOverride = await promptConfirm(
+			`Do you want to override the ${path.basename(overrideArr[i].fileName)} file?`,
+		);
+
+		if (shouldOverride) {
+			resultData = updateFilesArray(
+				resultData,
+				overrideArr[i].fileName,
+				meshConfigName,
+				overrideArr[i].index,
+			);
+		}
 	}
 
 	return resultData;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -12,6 +12,8 @@ governing permissions and limitations under the License.
 
 const fs = require('fs');
 const inquirer = require('inquirer');
+const path = require('path');
+const jsmin = require('jsmin').jsmin;
 
 const Config = require('@adobe/aio-lib-core-config');
 const { getToken, context } = require('@adobe/aio-lib-ims');
@@ -311,7 +313,7 @@ const selectWorkspace = async (orgId, projectId, imsOrgTitle, projectTitle) => {
 			throw new Error('No workspace selected');
 		}
 	} else {
-		this.error(
+		throw new Error(
 			'No workspaces found for the selected organization: ' +
 				imsOrgTitle +
 				' and project: ' +
@@ -459,6 +461,248 @@ async function promptInput(message) {
 	return selected.item;
 }
 
+/**
+ * Parse the meshConfig and get the list of (local) files to be imported
+ *
+ * @param data MeshConfig
+ */
+function getFilesInMeshConfig(data, meshConfigName) {
+	//ignore if the file names start with http or https
+	const fileURLRegex = /^(http|s:\/\/)/;
+
+	let filesList = [];
+
+	data.meshConfig.sources.forEach(source => {
+		// JSONSchema handler
+		source.handler.JsonSchema?.operations.forEach(operation => {
+			if (operation.requestSchema && !fileURLRegex.test(operation.requestSchema)) {
+				filesList.push(operation.requestSchema);
+			}
+			if (operation.responseSchema && !fileURLRegex.test(operation.responseSchema)) {
+				filesList.push(operation.responseSchema);
+			}
+			if (operation.requestSample && !fileURLRegex.test(operation.requestSample)) {
+				filesList.push(operation.requestSample);
+			}
+			if (operation.responseSample && !fileURLRegex.test(operation.responseSample)) {
+				filesList.push(operation.responseSample);
+			}
+		});
+
+		// OpenAPI handler
+		if (source.handler.openapi && !fileURLRegex.test(source.handler.openapi.source)) {
+			filesList.push(source.handler.openapi.source);
+		}
+	});
+
+	// Additional Resolvers
+	data.meshConfig.additionalResolvers?.forEach(additionalResolver => {
+		if (!fileURLRegex.test(additionalResolver)) {
+			filesList.push(additionalResolver);
+		}
+	});
+
+	// ReplaceField Transform - source level
+	data.meshConfig.sources.transforms?.forEach(transform => {
+		transform.replaceField?.replacements.forEach(replacement => {
+			if (replacement.composer && !fileURLRegex.test(replacement.composer)) {
+				filesList.push(replacement.composer);
+			}
+		});
+	});
+
+	// ReplaceField Transform - mesh level
+	data.meshConfig.transforms?.forEach(transform => {
+		transform.replaceField?.replacements.forEach(replacement => {
+			if (replacement.composer && !fileURLRegex.test(replacement.composer)) {
+				filesList.push(replacement.composer);
+			}
+		});
+	});
+
+	if (filesList) {
+		validateFileName(filesList, data);
+		validateFilePaths(filesList, meshConfigName);
+		validateFileType(filesList);
+	}
+	// console.log('sdvdfb');
+
+	return filesList;
+}
+
+/**
+ * Validate if the meshConfig file and other (js, json) files are in same directory
+ *
+ * @param filesList List of files in meshConfig
+ * @param meshConfigName MeshConfig file name
+ */
+function validateFilePaths(filesList, meshConfigName) {
+	try {
+		for (let file of filesList) {
+			// throw error, if the meshConfig and the file are not in the same directory
+			if (!fs.existsSync(path.resolve(path.dirname(meshConfigName), file))) {
+				throw new Error(
+					`Please make sure the files ${path.basename(file)} and ${path.basename(
+						meshConfigName,
+					)} are in the same directory`,
+				);
+			}
+		}
+	} catch (err) {
+		throw new Error(err.message);
+	}
+}
+
+/**
+ * Check if the files are of valid types .js, .json
+ *
+ * @param filesList List of files in mesh config
+ */
+function validateFileType(filesList) {
+	const filesWithInvalidTypes = [];
+
+	filesList.forEach(file => {
+		const extension = path.extname(file);
+		const isValidFileType = ['.js', '.json'].includes(extension);
+
+		if (!isValidFileType) {
+			filesWithInvalidTypes.push(file);
+		}
+	});
+
+	if (filesWithInvalidTypes.length) {
+		throw new Error(
+			`Mesh files must be JavaScript or JSON. Other file types are not supported. The following files are invalid: ${filesWithInvalidTypes}`,
+		);
+	}
+}
+
+/**
+ * Validate the filenames
+ *
+ * @param filesList Files in sources, tranforms or additionalResolvers in the meshConfig
+ * @param data MeshConfig
+ */
+function validateFileName(filesList, data) {
+	const filesWithInvalidNames = [];
+
+	// Check if the file names are less than 25 characters
+	filesList.forEach(file => {
+		const fileName = path.basename(file);
+		if (fileName.length > 25) {
+			filesWithInvalidNames.push(fileName);
+		}
+	});
+
+	if (filesWithInvalidNames.length) {
+		throw new Error(
+			`Mesh file names must be less than 25 characters. The following file(s) are invalid: ${filesWithInvalidNames}`,
+		);
+	}
+
+	// check if the the filePaths in the files array match
+	// the fileNames in sources, transforms or additionalResolvers
+	if (data.meshConfig.files) {
+		for (let i = 0; i < data.meshConfig.files.length; i++) {
+			if (filesList.indexOf(data.meshConfig.files[i].path) == -1) {
+				throw new Error(
+					`Please make sure the file ${path.basename(
+						data.meshConfig.files[i].path,
+					)} is matching in both places in meshConfig`,
+				);
+			}
+		}
+	}
+}
+
+/**
+ * Import the files in the files array in meshConfig
+ *
+ * @param data MeshConfig
+ * @param filesList List of files in meshConfig
+ * @param meshConfigName MeshConfigName
+ * @param autoConfirmActionFlag The user won't be prompted any questions, if this flag is set
+ */
+async function importFiles(data, filesList, meshConfigName, autoConfirmActionFlag) {
+	let shouldOverride = true;
+
+	/**
+	 * Map of <fileName, <index, isVisited>>
+	 */
+	let visitedMap = new Map();
+
+	// initialize values for fileName keys as false
+	for (let i = 0; i < data.meshConfig.files?.length; i++) {
+		visitedMap.set(data.meshConfig.files[i].path, { index: i, isVisited: false });
+	}
+
+	for (let file of filesList) {
+		if (data.meshConfig.files) {
+			// if the file exists in the files array and is not visited, override it?
+			if (visitedMap.has(file) && !visitedMap.get(file).isVisited) {
+				let index = visitedMap.get(file).index;
+
+				visitedMap.set(file, { index: index, isVisited: true });
+
+				if (!autoConfirmActionFlag) {
+					shouldOverride = await promptConfirm(`Do you want to override the ${file} file?`);
+				}
+
+				if (shouldOverride) {
+					updateFilesArray(data, file, meshConfigName, index);
+				}
+			}
+
+			// if the files array exists, but the file does not exist in the array, append it
+			if (!visitedMap.get(file)) {
+				visitedMap.set(file, { index: visitedMap.size, isVisited: true });
+				updateFilesArray(data, file, meshConfigName, -1);
+			}
+		} else {
+			// if the files array does not exist in meshConfig, append it
+			updateFilesArray(data, file, meshConfigName, -1);
+		}
+	}
+}
+
+/**
+ * Append/override files to the files array in meshConfig
+ *
+ * @param data MeshConfig
+ * @param file File to append or override
+ * @param meshConfigName MeshConfig name
+ * @param index Append operation if index is -1, else override, it is the index where the override takes place
+ */
+function updateFilesArray(data, file, meshConfigName, index) {
+	const readFileData = fs.readFileSync(path.resolve(file), { encoding: 'utf-8' });
+
+	//data to be overridden or appended
+	const dataInFilesArray = jsmin(readFileData);
+
+	if (index >= 0) {
+		data.meshConfig.files[index] = {
+			path: `${file}`,
+			content: `${dataInFilesArray}`,
+		};
+	} else {
+		//if the files array does not exist
+		if (!data.meshConfig.files) {
+			data.meshConfig.files = [];
+		}
+
+		//if the files arrray exists, we append the file path and content in meshConfig
+		data.meshConfig.files.push({
+			path: `./${path.basename(file)}`,
+			content: `${dataInFilesArray}`,
+		});
+	}
+
+	fs.writeFileSync(path.resolve(meshConfigName), JSON.stringify(data, null, 2), err => {
+		if (err) throw err;
+		this.log(`${file} appended to the meshConfig`);
+	});
+}
+
 module.exports = {
 	promptInput,
 	promptConfirm,
@@ -468,4 +712,6 @@ module.exports = {
 	initRequestId,
 	promptSelect,
 	promptMultiselect,
+	getFilesInMeshConfig,
+	importFiles,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -518,7 +518,7 @@ async function importFiles(data, filesListArray, meshConfigName, autoConfirmActi
 		throw new Error(
 			`Please make sure the file(s): ${filesNotFound.join(', ')} and ${path.basename(
 				meshConfigName,
-			)} are in the same directory`,
+			)} are in the same directory/subdirectory`,
 		);
 	}
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -12,9 +12,6 @@ governing permissions and limitations under the License.
 
 const fs = require('fs');
 const inquirer = require('inquirer');
-const path = require('path');
-const jsmin = require('jsmin').jsmin;
-
 const Config = require('@adobe/aio-lib-core-config');
 const { getToken, context } = require('@adobe/aio-lib-ims');
 const { CLI } = require('@adobe/aio-lib-ims/src/context');
@@ -24,7 +21,7 @@ const { getCliEnv } = require('@adobe/aio-lib-env');
 const logger = require('../src/classes/logger');
 const { UUID } = require('./classes/UUID');
 const CONSTANTS = require('./constants');
-const { objToString } = require('./utils');
+const { objToString, updateFilesArray } = require('./utils');
 
 const { DEV_CONSOLE_BASE_URL, DEV_CONSOLE_API_KEY, AIO_CLI_API_KEY } = CONSTANTS;
 
@@ -462,164 +459,6 @@ async function promptInput(message) {
 }
 
 /**
- * Parse the meshConfig and get the list of (local) files to be imported
- *
- * @param data MeshConfig
- */
-function getFilesInMeshConfig(data, meshConfigName) {
-	//ignore if the file names start with http or https
-	const fileURLRegex = /^(http|s:\/\/)/;
-
-	let filesList = [];
-
-	data.meshConfig.sources.forEach(source => {
-		// JSONSchema handler
-		source.handler.JsonSchema?.operations.forEach(operation => {
-			if (operation.requestSchema && !fileURLRegex.test(operation.requestSchema)) {
-				filesList.push(operation.requestSchema);
-			}
-			if (operation.responseSchema && !fileURLRegex.test(operation.responseSchema)) {
-				filesList.push(operation.responseSchema);
-			}
-			if (operation.requestSample && !fileURLRegex.test(operation.requestSample)) {
-				filesList.push(operation.requestSample);
-			}
-			if (operation.responseSample && !fileURLRegex.test(operation.responseSample)) {
-				filesList.push(operation.responseSample);
-			}
-		});
-
-		// OpenAPI handler
-		if (source.handler.openapi && !fileURLRegex.test(source.handler.openapi.source)) {
-			filesList.push(source.handler.openapi.source);
-		}
-	});
-
-	// Additional Resolvers
-	data.meshConfig.additionalResolvers?.forEach(additionalResolver => {
-		if (!fileURLRegex.test(additionalResolver)) {
-			filesList.push(additionalResolver);
-		}
-	});
-
-	// ReplaceField Transform - source level
-	data.meshConfig.sources.transforms?.forEach(transform => {
-		transform.replaceField?.replacements.forEach(replacement => {
-			if (replacement.composer && !fileURLRegex.test(replacement.composer)) {
-				filesList.push(replacement.composer);
-			}
-		});
-	});
-
-	// ReplaceField Transform - mesh level
-	data.meshConfig.transforms?.forEach(transform => {
-		transform.replaceField?.replacements.forEach(replacement => {
-			if (replacement.composer && !fileURLRegex.test(replacement.composer)) {
-				filesList.push(replacement.composer);
-			}
-		});
-	});
-
-	try {
-		if (filesList.length) {
-			validateFileType(filesList);
-			validateFileName(filesList, data);
-			validateFilePaths(filesList, meshConfigName);
-		}
-	} catch (err) {
-		logger.error(err.message);
-		throw new Error(err.message);
-	}
-
-	return filesList;
-}
-
-/**
- * Validate if the meshConfig file and other (js, json) files are in same directory
- *
- * @param filesList List of files in meshConfig
- * @param meshConfigName MeshConfig file name
- */
-function validateFilePaths(filesList, meshConfigName) {
-	try {
-		for (let file of filesList) {
-			// throw error, if the meshConfig and the file are not in the same directory
-			if (!fs.existsSync(path.resolve(path.dirname(meshConfigName), file))) {
-				throw new Error(
-					`Please make sure the files ${path.basename(file)} and ${path.basename(
-						meshConfigName,
-					)} are in the same directory`,
-				);
-			}
-		}
-	} catch (err) {
-		throw new Error(err.message);
-	}
-}
-
-/**
- * Check if the files are of valid types .js, .json
- *
- * @param filesList List of files in mesh config
- */
-function validateFileType(filesList) {
-	const filesWithInvalidTypes = [];
-
-	filesList.forEach(file => {
-		const extension = path.extname(file);
-		const isValidFileType = ['.js', '.json'].includes(extension);
-
-		if (!isValidFileType) {
-			filesWithInvalidTypes.push(file);
-		}
-	});
-
-	if (filesWithInvalidTypes.length) {
-		throw new Error(
-			`Mesh files must be JavaScript or JSON. Other file types are not supported. The following file(s) are invalid: ${path.basename(
-				filesWithInvalidTypes[0],
-			)}`,
-		);
-	}
-}
-
-/**
- * Validate the filenames
- *
- * @param filesList Files in sources, tranforms or additionalResolvers in the meshConfig
- * @param data MeshConfig
- */
-function validateFileName(filesList, data) {
-	const filesWithInvalidNames = [];
-
-	// Check if the file names are less than 25 characters
-	filesList.forEach(file => {
-		const fileName = path.basename(file);
-		if (fileName.length > 25) {
-			filesWithInvalidNames.push(fileName);
-		}
-	});
-
-	if (filesWithInvalidNames.length) {
-		throw new Error(
-			`Mesh file names must be less than 25 characters. The following file(s) are invalid: ${filesWithInvalidNames}`,
-		);
-	}
-
-	// check if the the filePaths in the files array match
-	// the fileNames in sources, transforms or additionalResolvers
-	if (data.meshConfig.files) {
-		for (let i = 0; i < data.meshConfig.files.length; i++) {
-			if (filesList.indexOf(data.meshConfig.files[i].path) == -1) {
-				throw new Error(
-					`Please make sure the file names are matching in both places in meshConfig`,
-				);
-			}
-		}
-	}
-}
-
-/**
  * Import the files in the files array in meshConfig
  *
  * @param data MeshConfig
@@ -670,55 +509,6 @@ async function importFiles(data, filesList, meshConfigName, autoConfirmActionFla
 	return data;
 }
 
-/**
- * Append/override files to the files array in meshConfig
- *
- * @param data MeshConfig
- * @param file File to append or override
- * @param meshConfigName MeshConfig name
- * @param index Append operation if index is -1, else override, it is the index where the override takes place
- */
-function updateFilesArray(data, file, meshConfigName, index) {
-	try {
-		const readFileData = fs.readFileSync(path.resolve(file), { encoding: 'utf-8' }, err => {
-			if (err) {
-				throw new Error(err);
-			}
-		});
-
-		//data to be overridden or appended
-		const dataInFilesArray = jsmin(readFileData);
-
-		if (index >= 0) {
-			data.meshConfig.files[index] = {
-				path: `${file}`,
-				content: `${dataInFilesArray}`,
-			};
-		} else {
-			//if the files array does not exist
-			if (!data.meshConfig.files) {
-				data.meshConfig.files = [];
-			}
-
-			//if the files arrray exists, we append the file path and content in meshConfig
-			data.meshConfig.files.push({
-				path: `./${path.basename(file)}`,
-				content: `${dataInFilesArray}`,
-			});
-		}
-
-		fs.writeFileSync(path.resolve(meshConfigName), JSON.stringify(data, null, 2), err => {
-			if (err) {
-				throw new Error(err);
-			}
-			logger.debug(`${file} appended to the meshConfig`);
-		});
-	} catch (err) {
-		logger.error(err.message);
-		throw new Error(err.message);
-	}
-}
-
 module.exports = {
 	promptInput,
 	promptConfirm,
@@ -728,6 +518,5 @@ module.exports = {
 	initRequestId,
 	promptSelect,
 	promptMultiselect,
-	getFilesInMeshConfig,
 	importFiles,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -612,9 +612,7 @@ function validateFileName(filesList, data) {
 		for (let i = 0; i < data.meshConfig.files.length; i++) {
 			if (filesList.indexOf(data.meshConfig.files[i].path) == -1) {
 				throw new Error(
-					`Please make sure the file ${path.basename(
-						data.meshConfig.files[i].path,
-					)} is matching in both places in meshConfig`,
+					`Please make sure the file names are matching in both places in meshConfig`,
 				);
 			}
 		}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -517,7 +517,7 @@ async function importFiles(data, filesListArray, meshConfigName, autoConfirmActi
 		}
 
 		throw new Error(
-			`Please make sure the file(s): ${filesNotFound.join(', ')} and ${path.basename(
+			`Please make sure the files: ${filesNotFound.join(', ')} and ${path.basename(
 				meshConfigName,
 			)} are in the same directory`,
 		);

--- a/src/utils.js
+++ b/src/utils.js
@@ -214,8 +214,8 @@ function updateFilesArray(data, file, meshConfigName, index) {
 
 		if (index >= 0) {
 			data.meshConfig.files[index] = {
-				path: `${file}`,
-				content: `${dataInFilesArray}`,
+				path: file,
+				content: dataInFilesArray,
 			};
 		} else {
 			//if the files array does not exist
@@ -225,8 +225,8 @@ function updateFilesArray(data, file, meshConfigName, index) {
 
 			//if the files arrray exists, we append the file path and content in meshConfig
 			data.meshConfig.files.push({
-				path: `./${path.basename(file)}`,
-				content: `${dataInFilesArray}`,
+				path: file,
+				content: dataInFilesArray,
 			});
 		}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,7 +63,7 @@ const jsonFlag = Flags.boolean({
  *
  * @param data MeshConfig
  */
-function getFilesInMeshConfig(data, meshConfigName) {
+function getFilesInMeshConfig(data) {
 	//ignore if the file names start with http or https
 	const fileURLRegex = /^(http|s:\/\/)/;
 
@@ -121,7 +121,6 @@ function getFilesInMeshConfig(data, meshConfigName) {
 		if (filesList.length) {
 			validateFileType(filesList);
 			validateFileName(filesList, data);
-			validateFilePaths(filesList, meshConfigName);
 		}
 	} catch (err) {
 		logger.error(err.message);
@@ -129,29 +128,6 @@ function getFilesInMeshConfig(data, meshConfigName) {
 	}
 
 	return filesList;
-}
-
-/**
- * Validate if the meshConfig file and other (js, json) files are in same directory
- *
- * @param filesList List of files in meshConfig
- * @param meshConfigName MeshConfig file name
- */
-function validateFilePaths(filesList, meshConfigName) {
-	try {
-		for (let file of filesList) {
-			// throw error, if the meshConfig and the file are not in the same directory
-			if (!fs.existsSync(path.resolve(path.dirname(meshConfigName), file))) {
-				throw new Error(
-					`Please make sure the files ${path.basename(file)} and ${path.basename(
-						meshConfigName,
-					)} are in the same directory.`,
-				);
-			}
-		}
-	} catch (err) {
-		throw new Error(err.message);
-	}
 }
 
 /**
@@ -205,12 +181,11 @@ function validateFileName(filesList, data) {
 
 	// check if the the filePaths in the files array match
 	// the fileNames in sources, transforms or additionalResolvers
+
 	if (data.meshConfig.files) {
 		for (let i = 0; i < data.meshConfig.files.length; i++) {
 			if (filesList.indexOf(data.meshConfig.files[i].path) == -1) {
-				throw new Error(
-					`Please make sure the file names are matching in both places in meshConfig.`,
-				);
+				throw new Error(`Please make sure the file names are matching in meshConfig.`);
 			}
 		}
 	}
@@ -257,12 +232,7 @@ function updateFilesArray(data, file, meshConfigName, index) {
 			});
 		}
 
-		fs.writeFileSync(path.resolve(meshConfigName), JSON.stringify(data, null, 2), err => {
-			if (err) {
-				throw new Error(err);
-			}
-			logger.debug(`${file} appended to the meshConfig`);
-		});
+		return data;
 	} catch (err) {
 		logger.error(err.message);
 		throw new Error(err.message);

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,7 +146,8 @@ function checkFilesAreUnderMeshDirectory(filesList, meshConfigName) {
 		if (
 			!path
 				.resolve(path.dirname(meshConfigName), filesList[i])
-				.includes(path.resolve(path.dirname(meshConfigName)))
+				.includes(path.resolve(path.dirname(meshConfigName))) ||
+			filesList[i].includes('~')
 		) {
 			invalidPaths.push(path.basename(filesList[i]));
 		}

--- a/src/utils.js
+++ b/src/utils.js
@@ -249,7 +249,7 @@ function updateFilesArray(data, file, meshConfigName, index) {
 		try {
 			//validate JSON file
 			if (path.extname(file) === '.json') {
-				readFileData = JSON.parse(readFileData);
+				readFileData = JSON.stringify(JSON.parse(readFileData));
 			}
 
 			//JS file validation/Lint is to be done

--- a/src/utils.js
+++ b/src/utils.js
@@ -143,15 +143,13 @@ function validateFileType(filesList) {
 		const isValidFileType = ['.js', '.json'].includes(extension);
 
 		if (!isValidFileType) {
-			filesWithInvalidTypes.push(file);
+			filesWithInvalidTypes.push(path.basename(file));
 		}
 	});
 
 	if (filesWithInvalidTypes.length) {
 		throw new Error(
-			`Mesh files must be JavaScript or JSON. Other file types are not supported. The following file(s) are invalid: ${path.basename(
-				filesWithInvalidTypes[0],
-			)}.`,
+			`Mesh files must be JavaScript or JSON. Other file types are not supported. The following file(s) are invalid: ${filesWithInvalidTypes}.`,
 		);
 	}
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -251,8 +251,6 @@ function updateFilesArray(data, file, meshConfigName, index) {
 			if (path.extname(file) === '.json') {
 				readFileData = JSON.stringify(JSON.parse(readFileData));
 			}
-
-			//JS file validation/Lint is to be done
 		} catch (err) {
 			logger.error(err.message);
 			throw new Error(`Invalid JSON content in ${path.basename(file)}`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const jsmin = require('jsmin').jsmin;
 const logger = require('../src/classes/logger');
-const promptConfirm = require('./helpers');
+
 /**
  * Returns the string representation of the object's path.
  * If the path evaluates to false, the default string is returned.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+const jsmin = require('jsmin').jsmin;
+const logger = require('../src/classes/logger');
+const promptConfirm = require('./helpers');
 /**
  * Returns the string representation of the object's path.
  * If the path evaluates to false, the default string is returned.
@@ -53,9 +58,222 @@ const jsonFlag = Flags.boolean({
 	default: false,
 });
 
+/**
+ * Parse the meshConfig and get the list of (local) files to be imported
+ *
+ * @param data MeshConfig
+ */
+function getFilesInMeshConfig(data, meshConfigName) {
+	//ignore if the file names start with http or https
+	const fileURLRegex = /^(http|s:\/\/)/;
+
+	let filesList = [];
+
+	data.meshConfig.sources.forEach(source => {
+		// JSONSchema handler
+		source.handler.JsonSchema?.operations.forEach(operation => {
+			if (operation.requestSchema && !fileURLRegex.test(operation.requestSchema)) {
+				filesList.push(operation.requestSchema);
+			}
+			if (operation.responseSchema && !fileURLRegex.test(operation.responseSchema)) {
+				filesList.push(operation.responseSchema);
+			}
+			if (operation.requestSample && !fileURLRegex.test(operation.requestSample)) {
+				filesList.push(operation.requestSample);
+			}
+			if (operation.responseSample && !fileURLRegex.test(operation.responseSample)) {
+				filesList.push(operation.responseSample);
+			}
+		});
+
+		// OpenAPI handler
+		if (source.handler.openapi && !fileURLRegex.test(source.handler.openapi.source)) {
+			filesList.push(source.handler.openapi.source);
+		}
+	});
+
+	// Additional Resolvers
+	data.meshConfig.additionalResolvers?.forEach(additionalResolver => {
+		if (!fileURLRegex.test(additionalResolver)) {
+			filesList.push(additionalResolver);
+		}
+	});
+
+	// ReplaceField Transform - source level
+	data.meshConfig.sources.transforms?.forEach(transform => {
+		transform.replaceField?.replacements.forEach(replacement => {
+			if (replacement.composer && !fileURLRegex.test(replacement.composer)) {
+				filesList.push(replacement.composer);
+			}
+		});
+	});
+
+	// ReplaceField Transform - mesh level
+	data.meshConfig.transforms?.forEach(transform => {
+		transform.replaceField?.replacements.forEach(replacement => {
+			if (replacement.composer && !fileURLRegex.test(replacement.composer)) {
+				filesList.push(replacement.composer);
+			}
+		});
+	});
+
+	try {
+		if (filesList.length) {
+			validateFileType(filesList);
+			validateFileName(filesList, data);
+			validateFilePaths(filesList, meshConfigName);
+		}
+	} catch (err) {
+		logger.error(err.message);
+		throw new Error(err.message);
+	}
+
+	return filesList;
+}
+
+/**
+ * Validate if the meshConfig file and other (js, json) files are in same directory
+ *
+ * @param filesList List of files in meshConfig
+ * @param meshConfigName MeshConfig file name
+ */
+function validateFilePaths(filesList, meshConfigName) {
+	try {
+		for (let file of filesList) {
+			// throw error, if the meshConfig and the file are not in the same directory
+			if (!fs.existsSync(path.resolve(path.dirname(meshConfigName), file))) {
+				throw new Error(
+					`Please make sure the files ${path.basename(file)} and ${path.basename(
+						meshConfigName,
+					)} are in the same directory.`,
+				);
+			}
+		}
+	} catch (err) {
+		throw new Error(err.message);
+	}
+}
+
+/**
+ * Check if the files are of valid types .js, .json
+ *
+ * @param filesList List of files in mesh config
+ */
+function validateFileType(filesList) {
+	const filesWithInvalidTypes = [];
+
+	filesList.forEach(file => {
+		const extension = path.extname(file);
+		const isValidFileType = ['.js', '.json'].includes(extension);
+
+		if (!isValidFileType) {
+			filesWithInvalidTypes.push(file);
+		}
+	});
+
+	if (filesWithInvalidTypes.length) {
+		throw new Error(
+			`Mesh files must be JavaScript or JSON. Other file types are not supported. The following file(s) are invalid: ${path.basename(
+				filesWithInvalidTypes[0],
+			)}.`,
+		);
+	}
+}
+
+/**
+ * Validate the filenames
+ *
+ * @param filesList Files in sources, tranforms or additionalResolvers in the meshConfig
+ * @param data MeshConfig
+ */
+function validateFileName(filesList, data) {
+	const filesWithInvalidNames = [];
+
+	// Check if the file names are less than 25 characters
+	filesList.forEach(file => {
+		const fileName = path.basename(file);
+		if (fileName.length > 25) {
+			filesWithInvalidNames.push(fileName);
+		}
+	});
+
+	if (filesWithInvalidNames.length) {
+		throw new Error(
+			`Mesh file names must be less than 25 characters. The following file(s) are invalid: ${filesWithInvalidNames}.`,
+		);
+	}
+
+	// check if the the filePaths in the files array match
+	// the fileNames in sources, transforms or additionalResolvers
+	if (data.meshConfig.files) {
+		for (let i = 0; i < data.meshConfig.files.length; i++) {
+			if (filesList.indexOf(data.meshConfig.files[i].path) == -1) {
+				throw new Error(
+					`Please make sure the file names are matching in both places in meshConfig.`,
+				);
+			}
+		}
+	}
+}
+
+/**
+ * Append/override files to the files array in meshConfig
+ *
+ * @param data MeshConfig
+ * @param file File to append or override
+ * @param meshConfigName MeshConfig name
+ * @param index Append operation if index is -1, else override, it is the index where the override takes place
+ */
+function updateFilesArray(data, file, meshConfigName, index) {
+	try {
+		const readFileData = fs.readFileSync(
+			path.resolve(path.dirname(meshConfigName), file),
+			{ encoding: 'utf-8' },
+			err => {
+				if (err) {
+					throw new Error(err);
+				}
+			},
+		);
+
+		//data to be overridden or appended
+		const dataInFilesArray = jsmin(readFileData);
+
+		if (index >= 0) {
+			data.meshConfig.files[index] = {
+				path: `${file}`,
+				content: `${dataInFilesArray}`,
+			};
+		} else {
+			//if the files array does not exist
+			if (!data.meshConfig.files) {
+				data.meshConfig.files = [];
+			}
+
+			//if the files arrray exists, we append the file path and content in meshConfig
+			data.meshConfig.files.push({
+				path: `./${path.basename(file)}`,
+				content: `${dataInFilesArray}`,
+			});
+		}
+
+		fs.writeFileSync(path.resolve(meshConfigName), JSON.stringify(data, null, 2), err => {
+			if (err) {
+				throw new Error(err);
+			}
+			logger.debug(`${file} appended to the meshConfig`);
+		});
+	} catch (err) {
+		logger.error(err.message);
+		throw new Error(err.message);
+	}
+}
+
 module.exports = {
 	objToString,
 	ignoreCacheFlag,
 	autoConfirmActionFlag,
 	jsonFlag,
+	getFilesInMeshConfig,
+	updateFilesArray,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4094,6 +4094,11 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+jsmin@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jsmin/-/jsmin-1.0.1.tgz#e7bd0dcd6496c3bf4863235bf461a3d98aa3b98c"
+  integrity sha512-OPuL5X/bFKgVdMvEIX3hnpx3jbVpFCrEM8pKPXjFkZUqg521r41ijdyTz7vACOhW6o1neVlcLyd+wkbK5fNHRg==
+
 json-interpolate@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/json-interpolate/-/json-interpolate-1.0.3.tgz#59b95c39a33e99721c82923dbcbcc8cb8d2d6d47"


### PR DESCRIPTION
Implement auto-importing files for create and update commands 
<!--- Provide a general summary of your changes in the Title above -->

## Description
Local development epic:
Right now, the files need to be copied, stringified, and minified before we add them to the meshConfig. This can get cumbersome.

To solve this problem, as part of this ticket, we are extending the CLI to auto-import the files by parsing the mesh config before creating or updating a mesh.

**Steps followed:**

1. Parse the mesh config and make a list of files that need to be imported. 
    - Identify where the files may be present in our MeshConfig
2. Validate file paths and throw an error with a list of all files that are wrong.
   - Check valid file types: js, json
   - Check if the length of file names is less than 25
   - If the files exist in the files array, check if it matches with the fileName in sources, transforms, additionalResolvers, or else error out.
3. If the file content is already present in the mesh config, take confirmation from the user if they want to override the content of the existing file. If "Yes", override else stop the operation.
4. If paths defined in source, transform or additionalResolvers are valid and they don’t exist in the files array, import those files, stringify, and minify them before adding them to the files array.

<!--- Describe your changes in detail -->

## Related Issue
[CEXT-1487](https://jira.corp.adobe.com/browse/CEXT-1487)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
To solve the problem of manually copying, stringifying, and minifying the files before we add them to the meshConfig, and hence, helping the customer to have CLI auto-import the files during create/update
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

The above feature has been tested using aio cli commands:

## Screenshots (if appropriate):
a. Create command returns error if file names are long (>25 characters)
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/230336015-2bc1a96c-66fb-454a-99ef-b966daeb350f.png">

b. Create command returns error if the files are not of JS, JSON type
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/230335263-48eb492c-635b-459e-b08f-35f6474df512.png">

c. Create command returns error if the files are not in the same directory as meshConfig (for not fully qualified meshConfig)
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/230336708-52d22754-b5a1-4b14-853c-5d537e37b456.png">

d. Create command returns error if the file names are not matching in meshConfig (in the below example '_schemaBody.json_' and '_schemaBodyTest.json_'
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/231365993-760fd4e3-7430-4dfb-b5d8-4ce52b008df6.png">

e. Create command imports the files to meshConfig (the files are appended in below example)
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/230339150-adfc34d2-1474-4b6b-9310-2b6d3d6059aa.png">
<img width="720" alt="image" src="https://user-images.githubusercontent.com/55528726/230339504-afb86ebd-92e2-45e1-b4fe-16d226a09c37.png">

f. Create command prompts the user if they want to override the files in meshConfig and proceeds to prompt the user to create the mesh or not
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/230340859-d15bf6fb-2545-46a4-942e-5c5dc75957cf.png">
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/230341211-f0ed6c56-83ed-4fbe-8b5d-f765b753d4a5.png">
Note that, in the above example, the schemaBody.json file is appended to meshConfig.

g. For fully-qualified meshConfig, if the files do not exist in file system, it should prompt to create the mesh
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/231367158-63c8796b-ffce-4ef8-9931-04e641bbaa25.png">
<img width="550" alt="image" src="https://user-images.githubusercontent.com/55528726/231367279-ad860d7b-4006-4086-b6c5-d1719d308ef4.png">

h. Create command fails if the file is outside the mesh directory (eg. '../additional-resolvers.js')
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/231951554-6049349d-dcd9-408f-9a56-7dd5cfb6eddb.png">

i. Create command fails if the file path starts from home directory (in Linux - '~' operator)
<img width="700" alt="image" src="https://user-images.githubusercontent.com/55528726/231958149-6d35a801-5b88-409b-9a53-1482448776ac.png">

The above scenarios are also supported by the update command.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
 
## Types of changes
1. Extended the create/update commands to support auto import
2. Extended helper classes to define new helper functions for validation & auto-import
3. Updated the unit tests for create & update
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
