### PR TITLE
Fix two tests that are failing in windows due to pathing issue.

### DIFF
--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -298,19 +298,13 @@ describe('create command tests', () => {
 			},
 		});
 		const runResult = CreateCommand.run();
-
+		const expected = [expect.stringMatching(/ENOENT: no such file or directory/)];
 		await expect(runResult).rejects.toEqual(
 			new Error(
 				'Unable to read the mesh configuration file provided. Please check the file and try again.',
 			),
 		);
-		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
-		[
-		  [
-		    "ENOENT: no such file or directory, open 'dummy_file_path'",
-		  ],
-		]
-	`);
+		expect(logSpy.mock.calls[0]).toEqual(expect.arrayContaining(expected));
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [

--- a/src/commands/api-mesh/source/__tests__/install.test.js
+++ b/src/commands/api-mesh/source/__tests__/install.test.js
@@ -104,9 +104,9 @@ describe('source:install command tests', () => {
 	});
 	test('Check executing with invalid file parameter', async () => {
 		await InstallCommand.run(['test-03', '-f=notexist.json']).catch(err => {
-			expect(err.message).toEqual(
+			expect(err.message).toContain(
 				`Something went wrong trying to read the variables file.` +
-					`\nENOENT: no such file or directory, open 'notexist.json'`,
+					`\nENOENT: no such file or directory`,
 			);
 		});
 	});


### PR DESCRIPTION
## Fix for tests failing in windows

Two of the tests are failing in windows due to pathing issue, so this is the PR that contains fix for that.

## Related Issue

CEXT-1707

## How Has This Been Tested?
Tested on local windows environment and verified that all tests are passing on both windows and WSL(linux).
command used - `yarn test`

## Screenshots (if appropriate):
(Test Pass Screenshot(windows))
![image](https://user-images.githubusercontent.com/118819311/233370685-82a54c9b-7263-4783-95d6-5ea1c2f31974.png)

(Test Pass Screenshot(WSL[linux]))
![image](https://user-images.githubusercontent.com/118819311/233370891-db6acc7a-15be-4f56-93c5-f823cfd14363.png)

