### PR TITLE
Resolved tests failing in windows, created branch from develop

### DIFF
--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -161,19 +161,13 @@ describe('create command tests', () => {
 			},
 		});
 		const runResult = CreateCommand.run();
-
+		const expected = [expect.stringMatching(/ENOENT: no such file or directory/)];
 		await expect(runResult).rejects.toEqual(
 			new Error(
 				'Unable to read the mesh configuration file provided. Please check the file and try again.',
 			),
 		);
-		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
-		[
-		  [
-		    "ENOENT: no such file or directory, open 'dummy_file_path'",
-		  ],
-		]
-	`);
+		expect(logSpy.mock.calls[0]).toEqual(expect.arrayContaining(expected));
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [

--- a/src/commands/api-mesh/source/__tests__/get.test.js
+++ b/src/commands/api-mesh/source/__tests__/get.test.js
@@ -122,7 +122,7 @@ describe('source:get command tests', () => {
 		const version = '1.1.1';
 		await GetCommand.run([`-s=${name}@${version}`]).catch(err => {
 			expect(err.message).toContain(
-				chalk.red(`The version \"1.1.1\" for source name \"test-01\" doesn't exist.`),
+				chalk.red(`The version "1.1.1" for source name "test-01" doesn't exist.`),
 			);
 		});
 	});

--- a/src/commands/api-mesh/source/__tests__/install.test.js
+++ b/src/commands/api-mesh/source/__tests__/install.test.js
@@ -104,9 +104,9 @@ describe('source:install command tests', () => {
 	});
 	test('Check executing with invalid file parameter', async () => {
 		await InstallCommand.run(['test-03', '-f=notexist.json']).catch(err => {
-			expect(err.message).toEqual(
+			expect(err.message).toContain(
 				`Something went wrong trying to read the variables file.` +
-					`\nENOENT: no such file or directory, open 'notexist.json'`,
+					`\nENOENT: no such file or directory`,
 			);
 		});
 	});


### PR DESCRIPTION
## Fix for tests failing in windows

Two of the tests are failing in windows due to pathing issue, so this is the PR that contains fix for that

## Related Issue
[CEXT-1707](https://jira.corp.adobe.com/browse/CEXT-1707)

## Related Pull Request
https://github.com/adobe/aio-cli-plugin-api-mesh/pull/62

