### PR TITLE
Fix module not found issue. Move "jsmin" under dependency section

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"pino": "^7.9.2",
 		"pino-pretty": "^7.6.0",
 		"pupa": "^3.1.0",
+		"jsmin": "1.0.1",
 		"source-registry-storage-adapter": "github:devx-services/source-registry-storage-adapter#main",
 		"uuid": "^8.3.2"
 	},
@@ -47,7 +48,6 @@
 		"husky": "7.0.4",
 		"jest": "^29.2.2",
 		"jest-junit": "^6.0.0",
-		"jsmin": "1.0.1",
 		"prettier": "2.2.1",
 		"stdout-stderr": "^0.1.9"
 	},


### PR DESCRIPTION
Move Jsmin under dependency section instead of dev-dependency.

## Description

On local getting error `ModuleLoadError: [MODULE_NOT_FOUND] require failed to load`.
`Cannot
 »    find module 'jsmin'`

So, moving `jsmin` module inside dependency section under package.json.