### PR TITLE
Cext 1784/ti mesh url update

### DIFF
--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -295,8 +295,8 @@ describe('create command tests', () => {
 
 	test('should create and return Ti mesh url if a valid mesh config file for TI client is provided', async () => {
 		let fetchedMeshConfig = sampleCreateMeshConfig;
-		fetchedMeshConfig.meshConfig.meshId = 'dummy_id';
-		fetchedMeshConfig.meshConfig.meshURL = 'https://tigraph.adobe.io';
+		fetchedMeshConfig.meshId = 'dummy_id';
+		fetchedMeshConfig.meshURL = 'https://tigraph.adobe.io';
 		getMesh.mockResolvedValue(fetchedMeshConfig);
 
 		const runResult = await CreateCommand.run();
@@ -347,7 +347,7 @@ describe('create command tests', () => {
 		  "mesh": {
 		    "meshConfig": {
 		      "meshId": "dummy_id",
-		      "meshURL": "https://tigraph.adobe.io",
+		      "meshURL": "",
 		      "sources": [
 		        {
 		          "handler": {
@@ -586,7 +586,7 @@ describe('create command tests', () => {
 		  [
 		    "Mesh Endpoint: %s
 		",
-		    "https://graph.adobe.io/api/dummy_mesh_id/graphql?api_key=dummy_api_key",
+		    "https://tigraph.adobe.io/dummy_mesh_id/graphql?api_key=dummy_api_key",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -22,6 +22,7 @@ const {
 	importFiles,
 } = require('../../../helpers');
 const {
+	getMesh,
 	createMesh,
 	createAPIMeshCredentials,
 	subscribeCredentialToMeshService,
@@ -81,6 +82,12 @@ describe('create command tests', () => {
 			id: 'dummy_id',
 		});
 		subscribeCredentialToMeshService.mockResolvedValue(['dummy_service']);
+
+		let fetchedMeshConfig = sampleCreateMeshConfig;
+		fetchedMeshConfig.meshConfig.meshId = 'dummy_id';
+		fetchedMeshConfig.meshConfig.meshURL = '';
+
+		getMesh.mockResolvedValue(fetchedMeshConfig);
 
 		parseSpy = jest.spyOn(CreateCommand.prototype, 'parse');
 		parseSpy.mockResolvedValue({
@@ -230,6 +237,8 @@ describe('create command tests', () => {
 		  },
 		  "mesh": {
 		    "meshConfig": {
+		      "meshId": "dummy_id",
+		      "meshURL": "",
 		      "sources": [
 		        {
 		          "handler": {
@@ -669,6 +678,8 @@ describe('create command tests', () => {
 		  },
 		  "mesh": {
 		    "meshConfig": {
+		      "meshId": "dummy_id",
+		      "meshURL": "",
 		      "sources": [
 		        {
 		          "handler": {

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -84,8 +84,8 @@ describe('create command tests', () => {
 		subscribeCredentialToMeshService.mockResolvedValue(['dummy_service']);
 
 		let fetchedMeshConfig = sampleCreateMeshConfig;
-		fetchedMeshConfig.meshConfig.meshId = 'dummy_id';
-		fetchedMeshConfig.meshConfig.meshURL = '';
+		fetchedMeshConfig.meshId = 'dummy_id';
+		fetchedMeshConfig.meshURL = '';
 
 		getMesh.mockResolvedValue(fetchedMeshConfig);
 
@@ -237,8 +237,6 @@ describe('create command tests', () => {
 		  },
 		  "mesh": {
 		    "meshConfig": {
-		      "meshId": "dummy_id",
-		      "meshURL": "",
 		      "sources": [
 		        {
 		          "handler": {
@@ -346,8 +344,6 @@ describe('create command tests', () => {
 		  },
 		  "mesh": {
 		    "meshConfig": {
-		      "meshId": "dummy_id",
-		      "meshURL": "",
 		      "sources": [
 		        {
 		          "handler": {
@@ -586,7 +582,7 @@ describe('create command tests', () => {
 		  [
 		    "Mesh Endpoint: %s
 		",
-		    "https://tigraph.adobe.io/dummy_mesh_id/graphql?api_key=dummy_api_key",
+		    "https://graph.adobe.io/api/dummy_mesh_id/graphql?api_key=dummy_api_key",
 		  ],
 		]
 	`);
@@ -787,8 +783,6 @@ describe('create command tests', () => {
 		  },
 		  "mesh": {
 		    "meshConfig": {
-		      "meshId": "dummy_id",
-		      "meshURL": "",
 		      "sources": [
 		        {
 		          "handler": {

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -293,6 +293,115 @@ describe('create command tests', () => {
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
 	});
 
+	test('should create and return Ti mesh url if a valid mesh config file for TI client is provided', async () => {
+		let fetchedMeshConfig = sampleCreateMeshConfig;
+		fetchedMeshConfig.meshConfig.meshId = 'dummy_id';
+		fetchedMeshConfig.meshConfig.meshURL = 'https://tigraph.adobe.io';
+		getMesh.mockResolvedValue(fetchedMeshConfig);
+
+		const runResult = await CreateCommand.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(createMesh.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		  {
+		    "meshConfig": {
+		      "sources": [
+		        {
+		          "handler": {
+		            "graphql": {
+		              "endpoint": "<gql_endpoint>",
+		            },
+		          },
+		          "name": "<api_name>",
+		        },
+		      ],
+		    },
+		  },
+		]
+	`);
+		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		]
+	`);
+		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
+		[
+		  "1234",
+		  "5678",
+		  "123456789",
+		  "dummy_id",
+		]
+	`);
+		expect(runResult).toMatchInlineSnapshot(`
+		{
+		  "adobeIdIntegrationsForWorkspace": {
+		    "apiKey": "dummy_api_key",
+		    "id": "dummy_id",
+		  },
+		  "mesh": {
+		    "meshConfig": {
+		      "meshId": "dummy_id",
+		      "meshURL": "https://tigraph.adobe.io",
+		      "sources": [
+		        {
+		          "handler": {
+		            "graphql": {
+		              "endpoint": "<gql_endpoint>",
+		            },
+		          },
+		          "name": "<api_name>",
+		        },
+		      ],
+		    },
+		    "meshId": "dummy_mesh_id",
+		  },
+		  "sdkList": [
+		    "dummy_service",
+		  ],
+		}
+	`);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "******************************************************************************************************",
+		  ],
+		  [
+		    "Your mesh is being provisioned. Wait a few minutes before checking the status of your mesh %s",
+		    "dummy_mesh_id",
+		  ],
+		  [
+		    "To check the status of your mesh, run:",
+		  ],
+		  [
+		    "aio api-mesh:status",
+		  ],
+		  [
+		    "******************************************************************************************************",
+		  ],
+		  [
+		    "Successfully created API Key %s",
+		    "dummy_api_key",
+		  ],
+		  [
+		    "Successfully subscribed API Key %s to API Mesh service",
+		    "dummy_api_key",
+		  ],
+		  [
+		    "Mesh Endpoint: %s
+		",
+		    "https://tigraph.adobe.io/dummy_mesh_id/graphql?api_key=dummy_api_key",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+	});
+
 	test('should fail if mesh config file arg is missing', async () => {
 		parseSpy.mockResolvedValueOnce({
 			args: {},

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -67,8 +67,8 @@ describe('describe command tests', () => {
 		});
 
 		let fetchedMeshConfig = sampleCreateMeshConfig;
-		fetchedMeshConfig.meshConfig.meshId = 'dummy_id';
-		fetchedMeshConfig.meshConfig.meshURL = '';
+		fetchedMeshConfig.meshId = 'dummy_id';
+		fetchedMeshConfig.meshURL = '';
 
 		getMesh.mockResolvedValue(fetchedMeshConfig);
 	});
@@ -179,10 +179,60 @@ describe('describe command tests', () => {
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
 	});
 
-	test('should succeed if valid details are provided', async () => {
+	test('should return Non TI url if request is Non Ti', async () => {
+		const runResult = await DescribeCommand.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(describeMesh).toHaveBeenCalledWith(
+			selectedOrg.id,
+			selectedProject.id,
+			selectedWorkspace.id,
+		);
+		expect(runResult).toMatchInlineSnapshot(`
+		{
+		  "apiKey": "dummy_apiKey",
+		  "meshId": "dummy_meshId",
+		}
+	`);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Successfully retrieved mesh details 
+		",
+		  ],
+		  [
+		    "Org ID: %s",
+		    "1234",
+		  ],
+		  [
+		    "Project ID: %s",
+		    "5678",
+		  ],
+		  [
+		    "Workspace ID: %s",
+		    "123456789",
+		  ],
+		  [
+		    "Mesh ID: %s",
+		    "dummy_meshId",
+		  ],
+		  [
+		    "API Key: %s",
+		    "dummy_apiKey",
+		  ],
+		  [
+		    "Mesh Endpoint: %s
+		",
+		    "https://graph.adobe.io/api/dummy_meshId/graphql?api_key=dummy_apiKey",
+		  ],
+		]
+	`);
+	});
+
+	test('should return Ti URL if api return TI url', async () => {
 		let fetchedMeshConfig = sampleCreateMeshConfig;
-		fetchedMeshConfig.meshConfig.meshId = 'dummy_id';
-		fetchedMeshConfig.meshConfig.meshURL = 'https://tigraph.adobe.io';
+		fetchedMeshConfig.meshId = 'dummy_id';
+		fetchedMeshConfig.meshURL = 'https://tigraph.adobe.io';
 
 		getMesh.mockResolvedValue(fetchedMeshConfig);
 		const runResult = await DescribeCommand.run();
@@ -233,55 +283,5 @@ describe('describe command tests', () => {
 		]
 	`);
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
-	});
-
-	test('should return TI url if request is Ti', async () => {
-		const runResult = await DescribeCommand.run();
-
-		expect(initRequestId).toHaveBeenCalled();
-		expect(describeMesh).toHaveBeenCalledWith(
-			selectedOrg.id,
-			selectedProject.id,
-			selectedWorkspace.id,
-		);
-		expect(runResult).toMatchInlineSnapshot(`
-		{
-		  "apiKey": "dummy_apiKey",
-		  "meshId": "dummy_meshId",
-		}
-	`);
-		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
-		[
-		  [
-		    "Successfully retrieved mesh details 
-		",
-		  ],
-		  [
-		    "Org ID: %s",
-		    "1234",
-		  ],
-		  [
-		    "Project ID: %s",
-		    "5678",
-		  ],
-		  [
-		    "Workspace ID: %s",
-		    "123456789",
-		  ],
-		  [
-		    "Mesh ID: %s",
-		    "dummy_meshId",
-		  ],
-		  [
-		    "API Key: %s",
-		    "dummy_apiKey",
-		  ],
-		  [
-		    "Mesh Endpoint: %s
-		",
-		    "https://graph.adobe.io/api/dummy_meshId/graphql?api_key=dummy_apiKey",
-		  ],
-		]
-	`);
 	});
 });

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -28,7 +28,8 @@ jest.mock('../../../lib/devConsole');
 
 const DescribeCommand = require('../describe');
 const { initSdk, initRequestId } = require('../../../helpers');
-const { describeMesh } = require('../../../lib/devConsole');
+const { describeMesh, getMesh } = require('../../../lib/devConsole');
+const sampleCreateMeshConfig = require('../../__fixtures__/sample_mesh.json');
 
 const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' };
 const selectedProject = { id: '5678', title: 'Project01' };
@@ -64,6 +65,12 @@ describe('describe command tests', () => {
 				ignoreCache: mockIgnoreCacheFlag,
 			},
 		});
+
+		let fetchedMeshConfig = sampleCreateMeshConfig;
+		fetchedMeshConfig.meshConfig.meshId = 'dummy_id';
+		fetchedMeshConfig.meshConfig.meshURL = '';
+
+		getMesh.mockResolvedValue(fetchedMeshConfig);
 	});
 
 	afterEach(() => {

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -180,6 +180,62 @@ describe('describe command tests', () => {
 	});
 
 	test('should succeed if valid details are provided', async () => {
+		let fetchedMeshConfig = sampleCreateMeshConfig;
+		fetchedMeshConfig.meshConfig.meshId = 'dummy_id';
+		fetchedMeshConfig.meshConfig.meshURL = 'https://tigraph.adobe.io';
+
+		getMesh.mockResolvedValue(fetchedMeshConfig);
+		const runResult = await DescribeCommand.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(describeMesh).toHaveBeenCalledWith(
+			selectedOrg.id,
+			selectedProject.id,
+			selectedWorkspace.id,
+		);
+		expect(runResult).toMatchInlineSnapshot(`
+		{
+		  "apiKey": "dummy_apiKey",
+		  "meshId": "dummy_meshId",
+		}
+	`);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Successfully retrieved mesh details 
+		",
+		  ],
+		  [
+		    "Org ID: %s",
+		    "1234",
+		  ],
+		  [
+		    "Project ID: %s",
+		    "5678",
+		  ],
+		  [
+		    "Workspace ID: %s",
+		    "123456789",
+		  ],
+		  [
+		    "Mesh ID: %s",
+		    "dummy_meshId",
+		  ],
+		  [
+		    "API Key: %s",
+		    "dummy_apiKey",
+		  ],
+		  [
+		    "Mesh Endpoint: %s
+		",
+		    "https://tigraph.adobe.io/dummy_meshId/graphql?api_key=dummy_apiKey",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+	});
+
+	test('should return TI url if request is Ti', async () => {
 		const runResult = await DescribeCommand.run();
 
 		expect(initRequestId).toHaveBeenCalled();
@@ -227,6 +283,5 @@ describe('describe command tests', () => {
 		  ],
 		]
 	`);
-		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
 	});
 });

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -151,11 +151,11 @@ class CreateCommand extends Command {
 								adobeIdIntegrationsForWorkspace.apiKey,
 							);
 
-							const { meshConfig } = await getMesh(imsOrgId, projectId, workspaceId, mesh.meshId);
+							const { meshURL } = await getMesh(imsOrgId, projectId, workspaceId, mesh.meshId);
 							const meshUrl =
-								meshConfig.meshURL === ''
+								meshURL === '' || meshURL === undefined
 									? MULTITENANT_GRAPHQL_SERVER_BASE_URL
-									: meshConfig.meshURL;
+									: meshURL;
 
 							this.log(
 								'Mesh Endpoint: %s\n',

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -151,8 +151,11 @@ class CreateCommand extends Command {
 								adobeIdIntegrationsForWorkspace.apiKey,
 							);
 
-							const { meshConfig }  = await getMesh(imsOrgId, projectId, workspaceId, mesh.meshId);
-							const meshUrl = meshConfig.meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshConfig.meshURL;
+							const { meshConfig } = await getMesh(imsOrgId, projectId, workspaceId, mesh.meshId);
+							const meshUrl =
+								meshConfig.meshURL === ''
+									? MULTITENANT_GRAPHQL_SERVER_BASE_URL
+									: meshConfig.meshURL;
 
 							this.log(
 								'Mesh Endpoint: %s\n',

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -25,6 +25,7 @@ const {
 	validateAndInterpolateMesh,
 } = require('../../utils');
 const {
+	getMesh,
 	createMesh,
 	createAPIMeshCredentials,
 	subscribeCredentialToMeshService,
@@ -150,9 +151,12 @@ class CreateCommand extends Command {
 								adobeIdIntegrationsForWorkspace.apiKey,
 							);
 
+							const { meshConfig }  = await getMesh(imsOrgId, projectId, workspaceId, mesh.meshId);
+							const meshUrl = meshConfig.meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshConfig.meshURL;
+
 							this.log(
 								'Mesh Endpoint: %s\n',
-								`${MULTITENANT_GRAPHQL_SERVER_BASE_URL}/${mesh.meshId}/graphql?api_key=${adobeIdIntegrationsForWorkspace.apiKey}`,
+								`${meshUrl}/${mesh.meshId}/graphql?api_key=${adobeIdIntegrationsForWorkspace.apiKey}`,
 							);
 						} else {
 							this.log(

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -52,9 +52,9 @@ class DescribeCommand extends Command {
 					this.log('Workspace ID: %s', workspaceId);
 					this.log('Mesh ID: %s', meshId);
 
-					const { meshConfig } = await getMesh(imsOrgId, projectId, workspaceId, meshId);
+					const { meshURL } = await getMesh(imsOrgId, projectId, workspaceId, meshId);
 					const meshUrl =
-						meshConfig.meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshConfig.meshURL;
+						meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshURL;
 
 					if (apiKey) {
 						this.log('API Key: %s', apiKey);

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -52,15 +52,13 @@ class DescribeCommand extends Command {
 					this.log('Workspace ID: %s', workspaceId);
 					this.log('Mesh ID: %s', meshId);
 
-					const { meshConfig }  = await getMesh(imsOrgId, projectId, workspaceId, meshId);
-					const meshUrl = meshConfig.meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshConfig.meshURL;
+					const { meshConfig } = await getMesh(imsOrgId, projectId, workspaceId, meshId);
+					const meshUrl =
+						meshConfig.meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshConfig.meshURL;
 
 					if (apiKey) {
 						this.log('API Key: %s', apiKey);
-						this.log(
-							'Mesh Endpoint: %s\n',
-							`${meshUrl}/${meshId}/graphql?api_key=${apiKey}`,
-						);
+						this.log('Mesh Endpoint: %s\n', `${meshUrl}/${meshId}/graphql?api_key=${apiKey}`);
 					}
 
 					return meshDetails;

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -15,7 +15,7 @@ const logger = require('../../classes/logger');
 const { initSdk, initRequestId } = require('../../helpers');
 const CONSTANTS = require('../../constants');
 const { ignoreCacheFlag } = require('../../utils');
-const { describeMesh } = require('../../lib/devConsole');
+const { describeMesh, getMesh } = require('../../lib/devConsole');
 
 require('dotenv').config();
 
@@ -52,11 +52,14 @@ class DescribeCommand extends Command {
 					this.log('Workspace ID: %s', workspaceId);
 					this.log('Mesh ID: %s', meshId);
 
+					const { meshConfig }  = await getMesh(imsOrgId, projectId, workspaceId, meshId);
+					const meshUrl = meshConfig.meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshConfig.meshURL;
+
 					if (apiKey) {
 						this.log('API Key: %s', apiKey);
 						this.log(
 							'Mesh Endpoint: %s\n',
-							`${MULTITENANT_GRAPHQL_SERVER_BASE_URL}/${meshId}/graphql?api_key=${apiKey}`,
+							`${meshUrl}/${meshId}/graphql?api_key=${apiKey}`,
 						);
 					}
 

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -53,8 +53,7 @@ class DescribeCommand extends Command {
 					this.log('Mesh ID: %s', meshId);
 
 					const { meshURL } = await getMesh(imsOrgId, projectId, workspaceId, meshId);
-					const meshUrl =
-						meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshURL;
+					const meshUrl = meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshURL;
 
 					if (apiKey) {
 						this.log('API Key: %s', apiKey);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Adding support for Mesh URL in create and describe commands


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/CEXT-1884
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested it with cli plugin linked from local for non Ti 
Could not test with TI org as I don't have access to them

## Screenshots (if appropriate):
![image](https://github.com/adobe/aio-cli-plugin-api-mesh/assets/13298685/6c0e7842-fef7-4e7f-aff3-d7688b0e1ff1)
![image](https://github.com/adobe/aio-cli-plugin-api-mesh/assets/13298685/a9aaaf28-e5f3-4077-b205-6ec751177299)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
