### PR TITLE
Cext 2049/additional resolvers file fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/src/commands/__fixtures__/sample_mesh_with_composer_files.json
+++ b/src/commands/__fixtures__/sample_mesh_with_composer_files.json
@@ -1,0 +1,42 @@
+{
+	"meshConfig": {
+		"sources": [
+			{
+				"name": "<json_source_name>",
+				"handler": {
+					"JsonSchema": {
+						"baseUrl": "<json_source__baseurl>",
+						"operations": [
+							{
+								"type": "Query",
+								"field": "<query>",
+								"path": "<query_path>",
+								"method": "POST",
+								"requestSchema": "./requestParams.json"
+							}
+						]
+					}
+				}
+			}
+		],
+		"plugins": [
+			{
+				"hooks": {
+					"beforeAll": {
+						"composer": "./hooks.js#functionName"
+					}
+				}
+			}
+		],
+		"files": [
+			{
+				"path": "./requestParams.json",
+				"content": "{\"type\":\"dummyContent\"}"
+			},
+			{
+				"path": "./hooks.js",
+				"content": "module.exports.functionName = () => { console.log('beforeAll hook'); }"
+			}
+		]
+	}
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -88,7 +88,9 @@ function getFilesInMeshConfig(data, meshConfigName) {
 	data.meshConfig.sources.transforms?.forEach(transform => {
 		transform.replaceField?.replacements.forEach(replacement => {
 			if (replacement.composer && !fileURLRegex.test(replacement.composer)) {
-				filesList.push(replacement.composer);
+				const [filename] = replacement.composer.split('#');
+
+				filesList.push(filename);
 			}
 		});
 	});
@@ -97,16 +99,51 @@ function getFilesInMeshConfig(data, meshConfigName) {
 	data.meshConfig.transforms?.forEach(transform => {
 		transform.replaceField?.replacements.forEach(replacement => {
 			if (replacement.composer && !fileURLRegex.test(replacement.composer)) {
-				filesList.push(replacement.composer);
+				const [filename] = replacement.composer.split('#');
+
+				filesList.push(filename);
 			}
 		});
 	});
+
+	// Hooks Plugin - mesh level
+	data.meshConfig.plugins?.forEach(plugin => {
+		if (plugin.hooks) {
+			if (plugin.hooks.beforeAll) {
+				const composer = plugin.hooks.beforeAll.composer;
+
+				if (composer && !fileURLRegex.test(composer)) {
+					const [filename] = composer.split('#');
+
+					filesList.push(filename);
+				}
+			}
+		}
+	});
+
+	// OnFetch plugin - mesh level
+	data.meshConfig.plugins?.forEach(plugin => {
+		if (plugin.onFetch) {
+			plugin.onFetch.forEach(onFetchConfig => {
+				const handler = onFetchConfig.handler;
+
+				if (handler) {
+					filesList.push(handler);
+				}
+			});
+		}
+	});
+
+	// remove duplicate files
+	filesList = [...new Set(filesList)];
+
+	logger.info(`Files to be imported: ${filesList.join(', ')}`);
 
 	try {
 		if (filesList.length) {
 			checkFilesAreUnderMeshDirectory(filesList, meshConfigName);
 			validateFileType(filesList);
-			validateFileName(filesList, data);
+			validateFileName(filesList);
 		}
 	} catch (err) {
 		logger.error(err.message);
@@ -226,9 +263,8 @@ function validateFileType(filesList) {
  * Validate the filenames
  *
  * @param filesList Files in sources, tranforms or additionalResolvers in the meshConfig
- * @param data MeshConfig
  */
-function validateFileName(filesList, data) {
+function validateFileName(filesList) {
 	const filesWithInvalidNames = [];
 
 	// Check if the file names are less than 25 characters
@@ -243,17 +279,6 @@ function validateFileName(filesList, data) {
 		throw new Error(
 			`Mesh file names must be less than 25 characters. The following file(s) are invalid: ${filesWithInvalidNames}.`,
 		);
-	}
-
-	// check if the the filePaths in the files array match
-	// the fileNames in sources, transforms or additionalResolvers
-
-	if (data.meshConfig.files) {
-		for (let i = 0; i < data.meshConfig.files.length; i++) {
-			if (filesList.indexOf(data.meshConfig.files[i].path) == -1) {
-				throw new Error(`Please make sure the file names are matching in meshConfig.`);
-			}
-		}
 	}
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,7 +79,7 @@ function getFilesInMeshConfig(data, meshConfigName) {
 
 	// Additional Resolvers
 	data.meshConfig.additionalResolvers?.forEach(additionalResolver => {
-		if (!fileURLRegex.test(additionalResolver)) {
+		if (typeof additionalResolver === 'string' && !fileURLRegex.test(additionalResolver)) {
 			filesList.push(additionalResolver);
 		}
 	});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a bug in local development file upload feature.

## Description

<!--- Describe your changes in detail -->
Additional resolvers can accept an object as well as string for file. Local development file upload feature tries to add additional resolver object to file list and errors out in validation. Adding a condition to check if additional resolver is a string before file upload feature.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Create a mesh with additional resolvers as object
https://jira.corp.adobe.com/browse/CEXT-2049
https://jira.corp.adobe.com/browse/CEXT-2052

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
