### PR TITLE
Pass workspaceName in headers of get mesh and describe mesh

### DIFF
--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -67,6 +67,7 @@ describe('create command tests', () => {
 			imsOrgId: selectedOrg.id,
 			projectId: selectedProject.id,
 			workspaceId: selectedWorkspace.id,
+			workspaceName: selectedWorkspace.title,
 		});
 
 		global.requestId = 'dummy_request_id';
@@ -272,6 +273,7 @@ describe('create command tests', () => {
 		  "1234",
 		  "5678",
 		  "123456789",
+		  "Workspace01",
 		  {
 		    "meshConfig": {
 		      "sources": [
@@ -379,6 +381,7 @@ describe('create command tests', () => {
 		  "1234",
 		  "5678",
 		  "123456789",
+		  "Workspace01",
 		  {
 		    "meshConfig": {
 		      "sources": [
@@ -953,6 +956,7 @@ describe('create command tests', () => {
 		  "1234",
 		  "5678",
 		  "123456789",
+		  "Workspace01",
 		  {
 		    "meshConfig": {
 		      "files": [
@@ -1228,6 +1232,7 @@ describe('create command tests', () => {
 		  "1234",
 		  "5678",
 		  "123456789",
+		  "Workspace01",
 		  {
 		    "files": [
 		      {
@@ -1370,6 +1375,7 @@ describe('create command tests', () => {
 		  "1234",
 		  "5678",
 		  "123456789",
+		  "Workspace01",
 		  {
 		    "meshConfig": {
 		      "files": [
@@ -1515,6 +1521,7 @@ describe('create command tests', () => {
 		  "1234",
 		  "5678",
 		  "123456789",
+		  "Workspace01",
 		  {
 		    "meshConfig": {
 		      "files": [
@@ -1657,6 +1664,7 @@ describe('create command tests', () => {
 		  "1234",
 		  "5678",
 		  "123456789",
+		  "Workspace01",
 		  {
 		    "meshConfig": {
 		      "files": [

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -468,7 +468,7 @@ describe('create command tests', () => {
 		  [
 		    "Mesh Endpoint: %s
 		",
-		    "https://tigraph.adobe.io/dummy_mesh_id/graphql?api_key=dummy_api_key",
+		    "https://tigraph.adobe.io/dummy_mesh_id/graphql",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -52,6 +52,7 @@ describe('describe command tests', () => {
 			imsOrgId: selectedOrg.id,
 			projectId: selectedProject.id,
 			workspaceId: selectedWorkspace.id,
+			workspaceName: selectedWorkspace.title,
 		});
 
 		global.requestId = 'dummy_request_id';
@@ -187,6 +188,7 @@ describe('describe command tests', () => {
 			selectedOrg.id,
 			selectedProject.id,
 			selectedWorkspace.id,
+			selectedWorkspace.title,
 		);
 		expect(runResult).toMatchInlineSnapshot(`
 		{
@@ -242,6 +244,7 @@ describe('describe command tests', () => {
 			selectedOrg.id,
 			selectedProject.id,
 			selectedWorkspace.id,
+			selectedWorkspace.title,
 		);
 		expect(runResult).toMatchInlineSnapshot(`
 		{

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -175,6 +175,11 @@ describe('describe command tests', () => {
 		    "Mesh ID: %s",
 		    "dummy_meshId",
 		  ],
+		  [
+		    "Mesh Endpoint: %s
+		",
+		    "https://graph.adobe.io/api/dummy_meshId/graphql",
+		  ],
 		]
 	`);
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
@@ -217,10 +222,6 @@ describe('describe command tests', () => {
 		  [
 		    "Mesh ID: %s",
 		    "dummy_meshId",
-		  ],
-		  [
-		    "API Key: %s",
-		    "dummy_apiKey",
 		  ],
 		  [
 		    "Mesh Endpoint: %s
@@ -275,13 +276,9 @@ describe('describe command tests', () => {
 		    "dummy_meshId",
 		  ],
 		  [
-		    "API Key: %s",
-		    "dummy_apiKey",
-		  ],
-		  [
 		    "Mesh Endpoint: %s
 		",
-		    "https://tigraph.adobe.io/dummy_meshId/graphql?api_key=dummy_apiKey",
+		    "https://tigraph.adobe.io/dummy_meshId/graphql",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/get.test.js
+++ b/src/commands/api-mesh/__tests__/get.test.js
@@ -49,6 +49,7 @@ describe('get command tests', () => {
 			imsOrgId: selectedOrg.id,
 			projectId: selectedProject.id,
 			workspaceId: selectedWorkspace.id,
+			workspaceName: selectedWorkspace.title,
 		});
 
 		global.requestId = 'dummy_request_id';

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -30,7 +30,7 @@ const {
 	subscribeCredentialToMeshService,
 } = require('../../lib/devConsole');
 
-const { MULTITENANT_GRAPHQL_SERVER_BASE_URL, TMOConstants } = CONSTANTS;
+const { MULTITENANT_GRAPHQL_SERVER_BASE_URL } = CONSTANTS;
 
 class CreateCommand extends Command {
 	static args = [{ name: 'file' }];
@@ -161,18 +161,14 @@ class CreateCommand extends Command {
 								meshURL === '' || meshURL === undefined
 									? MULTITENANT_GRAPHQL_SERVER_BASE_URL
 									: meshURL;
-
-							if (
-								meshUrl === TMOConstants.TMO_STAGE_URL ||
-								meshUrl === TMOConstants.TMO_SANDBOX_URL ||
-								meshUrl === TMOConstants.TMO_PROD_URL
-							) {
-								this.log('Mesh Endpoint: %s\n', `${meshUrl}/${mesh.meshId}/graphql`);
-							} else {
+							
+							if(adobeIdIntegrationsForWorkspace.apiKey && MULTITENANT_GRAPHQL_SERVER_BASE_URL.includes(meshUrl)){
 								this.log(
 									'Mesh Endpoint: %s\n',
 									`${meshUrl}/${mesh.meshId}/graphql?api_key=${adobeIdIntegrationsForWorkspace.apiKey}`,
 								);
+							} else {
+								this.log('Mesh Endpoint: %s\n', `${meshUrl}/${mesh.meshId}/graphql`);
 							}
 						} else {
 							this.log(

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -161,8 +161,11 @@ class CreateCommand extends Command {
 								meshURL === '' || meshURL === undefined
 									? MULTITENANT_GRAPHQL_SERVER_BASE_URL
 									: meshURL;
-							
-							if(adobeIdIntegrationsForWorkspace.apiKey && MULTITENANT_GRAPHQL_SERVER_BASE_URL.includes(meshUrl)){
+
+							if (
+								adobeIdIntegrationsForWorkspace.apiKey &&
+								MULTITENANT_GRAPHQL_SERVER_BASE_URL.includes(meshUrl)
+							) {
 								this.log(
 									'Mesh Endpoint: %s\n',
 									`${meshUrl}/${mesh.meshId}/graphql?api_key=${adobeIdIntegrationsForWorkspace.apiKey}`,

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -59,7 +59,7 @@ class CreateCommand extends Command {
 		const ignoreCache = await flags.ignoreCache;
 		const autoConfirmAction = await flags.autoConfirmAction;
 		const envFilePath = await flags.env;
-		const { imsOrgId, projectId, workspaceId } = await initSdk({
+		const { imsOrgId, projectId, workspaceId, workspaceName } = await initSdk({
 			ignoreCache,
 		});
 
@@ -109,7 +109,7 @@ class CreateCommand extends Command {
 
 		if (shouldContinue) {
 			try {
-				const mesh = await createMesh(imsOrgId, projectId, workspaceId, data);
+				const mesh = await createMesh(imsOrgId, projectId, workspaceId, workspaceName, data);
 
 				let sdkList = [];
 
@@ -150,7 +150,13 @@ class CreateCommand extends Command {
 								adobeIdIntegrationsForWorkspace.apiKey,
 							);
 
-							const { meshURL } = await getMesh(imsOrgId, projectId, workspaceId, mesh.meshId);
+							const { meshURL } = await getMesh(
+								imsOrgId,
+								projectId,
+								workspaceId,
+								workspaceName,
+								mesh.meshId,
+							);
 							const meshUrl =
 								meshURL === '' || meshURL === undefined
 									? MULTITENANT_GRAPHQL_SERVER_BASE_URL

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -60,11 +60,9 @@ class DescribeCommand extends Command {
 						meshId,
 					);
 					const meshUrl =
-								meshURL === '' || meshURL === undefined
-									? MULTITENANT_GRAPHQL_SERVER_BASE_URL
-									: meshURL;
-		
-					if(apiKey && MULTITENANT_GRAPHQL_SERVER_BASE_URL.includes(meshUrl)){
+						meshURL === '' || meshURL === undefined ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshURL;
+
+					if (apiKey && MULTITENANT_GRAPHQL_SERVER_BASE_URL.includes(meshUrl)) {
 						this.log('Mesh Endpoint: %s\n', `${meshUrl}/${meshId}/graphql?api_key=${apiKey}`);
 					} else {
 						this.log('Mesh Endpoint: %s\n', `${meshUrl}/${meshId}/graphql`);

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -35,12 +35,12 @@ class DescribeCommand extends Command {
 
 		const ignoreCache = await flags.ignoreCache;
 
-		const { imsOrgId, projectId, workspaceId } = await initSdk({
+		const { imsOrgId, projectId, workspaceId, workspaceName } = await initSdk({
 			ignoreCache,
 		});
 
 		try {
-			const meshDetails = await describeMesh(imsOrgId, projectId, workspaceId);
+			const meshDetails = await describeMesh(imsOrgId, projectId, workspaceId, workspaceName);
 
 			if (meshDetails) {
 				const { meshId, apiKey } = meshDetails;
@@ -52,7 +52,13 @@ class DescribeCommand extends Command {
 					this.log('Workspace ID: %s', workspaceId);
 					this.log('Mesh ID: %s', meshId);
 
-					const { meshURL } = await getMesh(imsOrgId, projectId, workspaceId, meshId);
+					const { meshURL } = await getMesh(
+						imsOrgId,
+						projectId,
+						workspaceId,
+						workspaceName,
+						meshId,
+					);
 					const meshUrl = meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshURL;
 
 					if (

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -19,7 +19,7 @@ const { describeMesh, getMesh } = require('../../lib/devConsole');
 
 require('dotenv').config();
 
-const { MULTITENANT_GRAPHQL_SERVER_BASE_URL, TMOConstants } = CONSTANTS;
+const { MULTITENANT_GRAPHQL_SERVER_BASE_URL } = CONSTANTS;
 
 class DescribeCommand extends Command {
 	static flags = {
@@ -59,18 +59,15 @@ class DescribeCommand extends Command {
 						workspaceName,
 						meshId,
 					);
-					const meshUrl = meshURL === '' ? MULTITENANT_GRAPHQL_SERVER_BASE_URL : meshURL;
-
-					if (
-						apiKey &&
-						(meshUrl === TMOConstants.TMO_STAGE_URL ||
-							meshUrl === TMOConstants.TMO_SANDBOX_URL ||
-							meshUrl === TMOConstants.TMO_PROD_URL)
-					) {
-						this.log('Mesh Endpoint: %s\n', `${meshUrl}/${meshId}/graphql`);
-					} else if (apiKey) {
-						this.log('API Key: %s', apiKey);
+					const meshUrl =
+								meshURL === '' || meshURL === undefined
+									? MULTITENANT_GRAPHQL_SERVER_BASE_URL
+									: meshURL;
+		
+					if(apiKey && MULTITENANT_GRAPHQL_SERVER_BASE_URL.includes(meshUrl)){
 						this.log('Mesh Endpoint: %s\n', `${meshUrl}/${meshId}/graphql?api_key=${apiKey}`);
+					} else {
+						this.log('Mesh Endpoint: %s\n', `${meshUrl}/${meshId}/graphql`);
 					}
 					return meshDetails;
 				} else {

--- a/src/commands/api-mesh/get.js
+++ b/src/commands/api-mesh/get.js
@@ -38,7 +38,7 @@ class GetCommand extends Command {
 		const ignoreCache = await flags.ignoreCache;
 		const json = await flags.json;
 
-		const { imsOrgId, projectId, workspaceId } = await initSdk({
+		const { imsOrgId, projectId, workspaceId, workspaceName } = await initSdk({
 			ignoreCache,
 			verbose: !json,
 		});
@@ -46,7 +46,7 @@ class GetCommand extends Command {
 		let meshId = null;
 
 		try {
-			meshId = await getMeshId(imsOrgId, projectId, workspaceId);
+			meshId = await getMeshId(imsOrgId, projectId, workspaceId, workspaceName);
 		} catch (err) {
 			this.error(
 				`Unable to get mesh ID. Please check the details and try again. RequestId: ${global.requestId}`,
@@ -55,7 +55,7 @@ class GetCommand extends Command {
 
 		if (meshId) {
 			try {
-				const mesh = await getMesh(imsOrgId, projectId, workspaceId, meshId);
+				const mesh = await getMesh(imsOrgId, projectId, workspaceId, workspaceName, meshId);
 
 				if (mesh) {
 					this.log('Successfully retrieved mesh %s', JSON.stringify(mesh, null, 2));

--- a/src/commands/api-mesh/source/__tests__/install.test.js
+++ b/src/commands/api-mesh/source/__tests__/install.test.js
@@ -39,6 +39,7 @@ initSdk.mockResolvedValue({
 	imsOrgId: selectedOrg.id,
 	projectId: selectedProject.id,
 	workspaceId: selectedWorkspace.id,
+	workspaceName: selectedWorkspace.title,
 });
 initRequestId.mockResolvedValue({});
 promptInput.mockResolvedValueOnce('test-03');
@@ -146,6 +147,7 @@ describe('source:install command tests', () => {
 			selectedOrg.id,
 			selectedProject.id,
 			selectedWorkspace.id,
+			selectedWorkspace.title,
 			'dummy_meshId',
 			res,
 		);

--- a/src/commands/api-mesh/source/install.js
+++ b/src/commands/api-mesh/source/install.js
@@ -36,7 +36,7 @@ class InstallCommand extends Command {
 		await initRequestId();
 		logger.info(`RequestId: ${global.requestId}`);
 		const ignoreCache = await flags.ignoreCache;
-		const { imsOrgId, projectId, workspaceId } = await initSdk({ ignoreCache });
+		const { imsOrgId, projectId, workspaceId, workspaceName } = await initSdk({ ignoreCache });
 		const filepath = flags['variable-file'];
 		let variables = flags.variable
 			? flags.variable.reduce((obj, val) => {
@@ -119,7 +119,7 @@ class InstallCommand extends Command {
 		}
 
 		try {
-			meshId = await getMeshId(imsOrgId, projectId, workspaceId);
+			meshId = await getMeshId(imsOrgId, projectId, workspaceId, workspaceName);
 		} catch (err) {
 			this.error(
 				`Unable to get mesh ID. Please check the details and try again. RequestId: ${global.requestId}`,
@@ -133,7 +133,7 @@ class InstallCommand extends Command {
 		}
 
 		try {
-			const mesh = await getMesh(imsOrgId, projectId, workspaceId, meshId);
+			const mesh = await getMesh(imsOrgId, projectId, workspaceId, meshId, workspaceName);
 
 			if (!mesh) {
 				this.error(
@@ -199,7 +199,7 @@ class InstallCommand extends Command {
 			}
 
 			try {
-				const response = await updateMesh(imsOrgId, projectId, workspaceId, meshId, {
+				const response = await updateMesh(imsOrgId, projectId, workspaceId, workspaceName, meshId, {
 					meshConfig: mesh.meshConfig,
 				});
 

--- a/src/commands/api-mesh/status.js
+++ b/src/commands/api-mesh/status.js
@@ -18,14 +18,14 @@ class StatusCommand extends Command {
 		const { flags } = await this.parse(StatusCommand);
 		const ignoreCache = await flags.ignoreCache;
 
-		const { imsOrgId, projectId, workspaceId } = await initSdk({
+		const { imsOrgId, projectId, workspaceId, workspaceName } = await initSdk({
 			ignoreCache,
 		});
 
 		let meshId = null;
 
 		try {
-			meshId = await getMeshId(imsOrgId, projectId, workspaceId);
+			meshId = await getMeshId(imsOrgId, projectId, workspaceId, workspaceName);
 		} catch (err) {
 			this.log(err.message);
 			this.error(
@@ -35,7 +35,7 @@ class StatusCommand extends Command {
 
 		if (meshId) {
 			try {
-				const mesh = await getMesh(imsOrgId, projectId, workspaceId, meshId);
+				const mesh = await getMesh(imsOrgId, projectId, workspaceId, workspaceName, meshId);
 				switch (mesh.meshStatus) {
 					case 'success':
 						this.log(

--- a/src/constants.js
+++ b/src/constants.js
@@ -21,7 +21,7 @@ const ProdConstants = {
 };
 const TMOConstants = {
 	TMO_STAGE_URL: 'https://tigraph-dev.adobe.io/api',
-	TMO_SANDBOX_URL: 'https://tigraph-sandbox.adobe.io/api',
+	TMO_SANDBOX_URL: 'https://mcprod.t-mobile2.dummycachetest.com/api',
 	TMO_PROD_URL: 'https://tigraph.adobe.io/api',
 };
 const envConstants = clientEnv === 'stage' ? StageConstants : ProdConstants;

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,10 +19,6 @@ const ProdConstants = {
 	AIO_CLI_API_KEY: 'aio-cli-console-auth',
 	SMS_BASE_URL: 'https://graph.adobe.io/api-admin',
 };
-const TMOConstants = {
-	TMO_STAGE_URL: 'https://tigraph-dev.adobe.io/api',
-	TMO_SANDBOX_URL: 'https://mcprod.t-mobile2.dummycachetest.com/api',
-	TMO_PROD_URL: 'https://tigraph.adobe.io/api',
-};
+
 const envConstants = clientEnv === 'stage' ? StageConstants : ProdConstants;
-module.exports = { ...envConstants, TMOConstants };
+module.exports = { ...envConstants };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -424,6 +424,7 @@ async function initSdk(options) {
 		imsOrgId: org.id,
 		projectId: project.id,
 		workspaceId: workspace.id,
+		workspaceName: workspace.title,
 	};
 }
 

--- a/src/lib/devConsole.js
+++ b/src/lib/devConsole.js
@@ -76,11 +76,11 @@ const getApiKeyCredential = async (organizationId, projectId, workspaceId) => {
 	}
 };
 
-const describeMesh = async (organizationId, projectId, workspaceId) => {
+const describeMesh = async (organizationId, projectId, workspaceId, workspaceName) => {
 	logger.info('Initiating Describe Mesh');
 
 	try {
-		const meshId = await getMeshId(organizationId, projectId, workspaceId);
+		const meshId = await getMeshId(organizationId, projectId, workspaceId, workspaceName);
 
 		logger.info('Response from getMeshId %s', meshId);
 
@@ -106,7 +106,7 @@ const describeMesh = async (organizationId, projectId, workspaceId) => {
 	}
 };
 
-const getMesh = async (organizationId, projectId, workspaceId, meshId) => {
+const getMesh = async (organizationId, projectId, workspaceId, workspaceName, meshId) => {
 	const { baseUrl: devConsoleUrl, accessToken, apiKey } = await getDevConsoleConfig();
 	const config = {
 		method: 'get',
@@ -114,6 +114,7 @@ const getMesh = async (organizationId, projectId, workspaceId, meshId) => {
 		headers: {
 			'Authorization': `Bearer ${accessToken}`,
 			'x-request-id': global.requestId,
+			'workspaceName': workspaceName,
 		},
 	};
 
@@ -187,7 +188,7 @@ const getMesh = async (organizationId, projectId, workspaceId, meshId) => {
 	}
 };
 
-const createMesh = async (organizationId, projectId, workspaceId, data) => {
+const createMesh = async (organizationId, projectId, workspaceId, workspaceName, data) => {
 	const { baseUrl: devConsoleUrl, accessToken, apiKey } = await getDevConsoleConfig();
 	const config = {
 		method: 'post',
@@ -443,7 +444,7 @@ const deleteMesh = async (organizationId, projectId, workspaceId, meshId) => {
 	}
 };
 
-const getMeshId = async (organizationId, projectId, workspaceId) => {
+const getMeshId = async (organizationId, projectId, workspaceId, workspaceName) => {
 	const { baseUrl: devConsoleUrl, accessToken, apiKey } = await getDevConsoleConfig();
 	logger.info('Initiating Mesh ID request');
 
@@ -453,6 +454,7 @@ const getMeshId = async (organizationId, projectId, workspaceId) => {
 		headers: {
 			'Authorization': `Bearer ${accessToken}`,
 			'x-request-id': global.requestId,
+			'workspaceName': workspaceName,
 		},
 	};
 


### PR DESCRIPTION
This PR contains the change in which we are passing workspaceName in headers in case of getMesh and describeMesh.

## Description

Passed workspaceName in headers of getMesh and describeMesh. Verified that all the tests passes post this change.

## Related Issue
https://jira.corp.adobe.com/browse/CEXT-2081

## Motivation and Context

In order to return the correct meshUrl based on workspaceName

## How Has This Been Tested?
Linked the cli plugin on local and verified that header is having workspaceName in case of getMesh and describeMesh(verified by adding breakpoints).

Also verified that all the api-mesh commands like: create, update, delete, describe and get are working in both TI and nonTI mode(verified against stage env).

Fix the existing tests and verified that all the existing tests are passing post this change.

## Screenshots (if appropriate):
![image](https://github.com/adobe/aio-cli-plugin-api-mesh/assets/118819311/2be03be8-6187-4c8f-9243-7fcd09dd84d1)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
