### PR TITLE
Test api cred

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.3.3",
+	"version": "3.0.0",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "2.3.3",
+	"version": "3.3.3",
 	"publishConfig": {
 		"access": "public"
 	},

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -294,21 +294,6 @@ describe('create command tests', () => {
 		  },
 		]
 	`);
-		/*expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		]
-	`);*/
-		/*expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		  "dummy_id",
-		]
-	`);*/
 		expect(runResult).toMatchInlineSnapshot(`
 		{
 		  "apiKey": "dummy_api_key",

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -75,9 +75,14 @@ describe('create command tests', () => {
 		errorLogSpy = jest.spyOn(CreateCommand.prototype, 'error');
 
 		createMesh.mockResolvedValue({
-			meshId: 'dummy_mesh_id',
-			meshConfig: sampleCreateMeshConfig.meshConfig,
+			mesh: {
+				meshId: 'dummy_mesh_id',
+				meshConfig: sampleCreateMeshConfig.meshConfig,
+			},
+			apiKey: 'dummy_api_key',
+			sdkList: ['dummy_service'],
 		});
+
 		createAPIMeshCredentials.mockResolvedValue({
 			apiKey: 'dummy_api_key',
 			id: 'dummy_id',
@@ -109,11 +114,11 @@ describe('create command tests', () => {
 		});
 		const output = await CreateCommand.run();
 		expect(output).toHaveProperty('mesh');
-		expect(output).toHaveProperty('adobeIdIntegrationsForWorkspace');
+		expect(output).toHaveProperty('apiKey');
+		expect(output).toHaveProperty('sdkList');
 		expect(output.mesh).toEqual(expect.objectContaining({ meshId: 'dummy_mesh_id' }));
-		expect(output.adobeIdIntegrationsForWorkspace).toEqual(
-			expect.objectContaining({ apiKey: 'dummy_api_key' }),
-		);
+		expect(output.apiKey).toEqual('dummy_api_key');
+		expect(output.sdkList).toEqual(['dummy_service']);
 	});
 
 	test('snapshot create command description', () => {
@@ -169,8 +174,12 @@ describe('create command tests', () => {
 
 	test('should pass if a valid mesh config file with composer files are provided', async () => {
 		createMesh.mockResolvedValueOnce({
-			meshId: 'dummy_mesh_id',
-			meshConfig: meshConfigWithComposerFiles.meshConfig,
+			mesh: {
+				meshId: 'dummy_mesh_id',
+				meshConfig: meshConfigWithComposerFiles.meshConfig,
+			},
+			apiKey: 'dummy_api_key',
+			sdkList: ['dummy_service'],
 		});
 
 		parseSpy.mockResolvedValueOnce({
@@ -184,10 +193,7 @@ describe('create command tests', () => {
 
 		expect(output).toMatchInlineSnapshot(`
 		{
-		  "adobeIdIntegrationsForWorkspace": {
-		    "apiKey": "dummy_api_key",
-		    "id": "dummy_id",
-		  },
+		  "apiKey": "dummy_api_key",
 		  "mesh": {
 		    "meshConfig": {
 		      "files": [
@@ -288,27 +294,24 @@ describe('create command tests', () => {
 		  },
 		]
 	`);
-		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
+		/*expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
 		[
 		  "1234",
 		  "5678",
 		  "123456789",
 		]
-	`);
-		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
+	`);*/
+		/*expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
 		[
 		  "1234",
 		  "5678",
 		  "123456789",
 		  "dummy_id",
 		]
-	`);
+	`);*/
 		expect(runResult).toMatchInlineSnapshot(`
 		{
-		  "adobeIdIntegrationsForWorkspace": {
-		    "apiKey": "dummy_api_key",
-		    "id": "dummy_id",
-		  },
+		  "apiKey": "dummy_api_key",
 		  "mesh": {
 		    "meshConfig": {
 		      "sources": [
@@ -395,27 +398,10 @@ describe('create command tests', () => {
 		  },
 		]
 	`);
-		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		]
-	`);
-		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		  "dummy_id",
-		]
-	`);
+
 		expect(runResult).toMatchInlineSnapshot(`
 		{
-		  "adobeIdIntegrationsForWorkspace": {
-		    "apiKey": "dummy_api_key",
-		    "id": "dummy_id",
-		  },
+		  "apiKey": "dummy_api_key",
 		  "mesh": {
 		    "meshConfig": {
 		      "sources": [
@@ -521,7 +507,7 @@ describe('create command tests', () => {
 	`);
 	});
 
-	test('should fail if create api credential api has failed', async () => {
+	test.skip('should fail if create api credential api has failed', async () => {
 		createAPIMeshCredentials.mockRejectedValue(new Error('create api credential api failed'));
 
 		const runResult = CreateCommand.run();
@@ -563,7 +549,7 @@ describe('create command tests', () => {
 	`);
 	});
 
-	test('should fail if subscribe credential to mesh service api has failed', async () => {
+	test.skip('should fail if subscribe credential to mesh service api has failed', async () => {
 		subscribeCredentialToMeshService.mockRejectedValueOnce(
 			new Error('subscribe credential to mesh service api failed'),
 		);
@@ -692,11 +678,11 @@ describe('create command tests', () => {
 		});
 		const output = await CreateCommand.run();
 		expect(output).toHaveProperty('mesh');
-		expect(output).toHaveProperty('adobeIdIntegrationsForWorkspace');
+		expect(output).toHaveProperty('apiKey');
+		expect(output).toHaveProperty('sdkList');
 		expect(output.mesh).toEqual(expect.objectContaining({ meshId: 'dummy_mesh_id' }));
-		expect(output.adobeIdIntegrationsForWorkspace).toEqual(
-			expect.objectContaining({ apiKey: 'dummy_api_key' }),
-		);
+		expect(output.apiKey).toEqual('dummy_api_key');
+		expect(output.sdkList).toEqual(['dummy_service']);
 	});
 
 	test('should return error if the mesh has placeholders and env file provided using --env flag is not found', async () => {
@@ -851,10 +837,7 @@ describe('create command tests', () => {
 		expect(promptConfirm).toHaveBeenCalledWith('Are you sure you want to create a mesh?');
 		expect(runResult).toMatchInlineSnapshot(`
 		{
-		  "adobeIdIntegrationsForWorkspace": {
-		    "apiKey": "dummy_api_key",
-		    "id": "dummy_id",
-		  },
+		  "apiKey": "dummy_api_key",
 		  "mesh": {
 		    "meshConfig": {
 		      "sources": [
@@ -930,8 +913,12 @@ describe('create command tests', () => {
 		};
 
 		createMesh.mockResolvedValueOnce({
-			meshId: 'dummy_mesh_id',
-			meshConfig: meshConfig,
+			mesh: {
+				meshId: 'dummy_mesh_id',
+				meshConfig: meshConfig,
+			},
+			apiKey: 'dummy_api_key',
+			sdkList: ['dummy_service'],
 		});
 
 		parseSpy.mockResolvedValueOnce({
@@ -984,28 +971,10 @@ describe('create command tests', () => {
 		  },
 		]
 	`);
-		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		]
-		`);
 
-		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		  "dummy_id",
-		]
-		`);
 		expect(output).toMatchInlineSnapshot(`
 		{
-		  "adobeIdIntegrationsForWorkspace": {
-		    "apiKey": "dummy_api_key",
-		    "id": "dummy_id",
-		  },
+		  "apiKey": "dummy_api_key",
 		  "mesh": {
 		    "meshConfig": {
 		      "files": [
@@ -1209,8 +1178,12 @@ describe('create command tests', () => {
 		importFiles.mockResolvedValueOnce(meshConfig);
 
 		createMesh.mockResolvedValueOnce({
-			meshId: 'dummy_mesh_id',
-			meshConfig: meshConfig,
+			mesh: {
+				meshId: 'dummy_mesh_id',
+				meshConfig: meshConfig,
+			},
+			apiKey: 'dummy_api_key',
+			sdkList: ['dummy_service'],
 		});
 
 		parseSpy.mockResolvedValueOnce({
@@ -1257,27 +1230,9 @@ describe('create command tests', () => {
 		  },
 		]
 	`);
-		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		]
-	`);
-		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		  "dummy_id",
-		]
-	`);
 		expect(output).toMatchInlineSnapshot(`
 		{
-		  "adobeIdIntegrationsForWorkspace": {
-		    "apiKey": "dummy_api_key",
-		    "id": "dummy_id",
-		  },
+		  "apiKey": "dummy_api_key",
 		  "mesh": {
 		    "meshConfig": {
 		      "files": [
@@ -1358,8 +1313,12 @@ describe('create command tests', () => {
 		});
 
 		createMesh.mockResolvedValueOnce({
-			meshId: 'dummy_mesh_id',
-			meshConfig: meshConfig,
+			mesh: {
+				meshId: 'dummy_mesh_id',
+				meshConfig: meshConfig,
+			},
+			apiKey: 'dummy_api_key',
+			sdkList: ['dummy_service'],
 		});
 
 		const output = await CreateCommand.run();
@@ -1401,28 +1360,10 @@ describe('create command tests', () => {
 		  },
 		]
 	`);
-		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		]
-	`);
 
-		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		  "dummy_id",
-		]
-	`);
 		expect(output).toMatchInlineSnapshot(`
 		{
-		  "adobeIdIntegrationsForWorkspace": {
-		    "apiKey": "dummy_api_key",
-		    "id": "dummy_id",
-		  },
+		  "apiKey": "dummy_api_key",
 		  "mesh": {
 		    "meshConfig": {
 		      "files": [
@@ -1503,8 +1444,12 @@ describe('create command tests', () => {
 		});
 
 		createMesh.mockResolvedValueOnce({
-			meshId: 'dummy_mesh_id',
-			meshConfig: meshConfig,
+			mesh: {
+				meshId: 'dummy_mesh_id',
+				meshConfig: meshConfig,
+			},
+			apiKey: 'dummy_api_key',
+			sdkList: ['dummy_service'],
 		});
 
 		const output = await CreateCommand.run();
@@ -1546,27 +1491,9 @@ describe('create command tests', () => {
 		  },
 		]
 	`);
-		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		]
-	`);
-		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		  "dummy_id",
-		]
-	`);
 		expect(output).toMatchInlineSnapshot(`
 		{
-		  "adobeIdIntegrationsForWorkspace": {
-		    "apiKey": "dummy_api_key",
-		    "id": "dummy_id",
-		  },
+		  "apiKey": "dummy_api_key",
 		  "mesh": {
 		    "meshConfig": {
 		      "files": [
@@ -1634,8 +1561,12 @@ describe('create command tests', () => {
 		};
 
 		createMesh.mockResolvedValueOnce({
-			meshId: 'dummy_mesh_id',
-			meshConfig: meshConfig,
+			mesh: {
+				meshId: 'dummy_mesh_id',
+				meshConfig: meshConfig,
+			},
+			apiKey: 'dummy_api_key',
+			sdkList: ['dummy_service'],
 		});
 
 		parseSpy.mockResolvedValueOnce({
@@ -1688,28 +1619,9 @@ describe('create command tests', () => {
 		  },
 		]
 	`);
-		expect(createAPIMeshCredentials.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		]
-		`);
-
-		expect(subscribeCredentialToMeshService.mock.calls[0]).toMatchInlineSnapshot(`
-		[
-		  "1234",
-		  "5678",
-		  "123456789",
-		  "dummy_id",
-		]
-		`);
 		expect(output).toMatchInlineSnapshot(`
 		{
-		  "adobeIdIntegrationsForWorkspace": {
-		    "apiKey": "dummy_api_key",
-		    "id": "dummy_id",
-		  },
+		  "apiKey": "dummy_api_key",
 		  "mesh": {
 		    "meshConfig": {
 		      "files": [

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -26,8 +26,6 @@ const {
 const {
 	getMesh,
 	createMesh,
-	createAPIMeshCredentials,
-	subscribeCredentialToMeshService,
 } = require('../../lib/devConsole');
 
 const { MULTITENANT_GRAPHQL_SERVER_BASE_URL, TMOConstants } = CONSTANTS;
@@ -109,11 +107,10 @@ class CreateCommand extends Command {
 
 		if (shouldContinue) {
 			try {
-				const mesh = await createMesh(imsOrgId, projectId, workspaceId, data);
-
-				let sdkList = [];
+				const { mesh, apiKey, sdkList} = await createMesh(imsOrgId, projectId, workspaceId, data);
 
 				if (mesh) {
+					
 					this.log(
 						'******************************************************************************************************',
 					);
@@ -127,27 +124,13 @@ class CreateCommand extends Command {
 						'******************************************************************************************************',
 					);
 
-					// create API key credential
-					const adobeIdIntegrationsForWorkspace = await createAPIMeshCredentials(
-						imsOrgId,
-						projectId,
-						workspaceId,
-					);
-
-					if (adobeIdIntegrationsForWorkspace) {
-						this.log('Successfully created API Key %s', adobeIdIntegrationsForWorkspace.apiKey);
-						// subscribe the credential to API mesh service
-						sdkList = await subscribeCredentialToMeshService(
-							imsOrgId,
-							projectId,
-							workspaceId,
-							adobeIdIntegrationsForWorkspace.id,
-						);
+					if (apiKey) {
+						this.log('Successfully created API Key %s', apiKey);
 
 						if (sdkList) {
 							this.log(
 								'Successfully subscribed API Key %s to API Mesh service',
-								adobeIdIntegrationsForWorkspace.apiKey,
+								apiKey,
 							);
 
 							const { meshURL } = await getMesh(imsOrgId, projectId, workspaceId, mesh.meshId);
@@ -165,22 +148,22 @@ class CreateCommand extends Command {
 							} else {
 								this.log(
 									'Mesh Endpoint: %s\n',
-									`${meshUrl}/${mesh.meshId}/graphql?api_key=${adobeIdIntegrationsForWorkspace.apiKey}`,
+									`${meshUrl}/${mesh.meshId}/graphql?api_key=${apiKey}`,
 								);
 							}
 						} else {
 							this.log(
 								'Unable to subscribe API Key %s to API Mesh service',
-								adobeIdIntegrationsForWorkspace.apiKey,
+								apiKey,
 							);
 						}
 					} else {
 						this.log('Unable to create API Key');
 					}
-					// Do not remove or rename return values.
-					// Template adobe/generator-app-api-mesh relies on "mesh" & "adobeIdIntegrationsForWorkspace" obj structure
+					// When renaming the return values, make sure to make necessary changes to
+					// template adobe/generator-app-api-mesh since it relies on "mesh" & "apiKey"
 					return {
-						adobeIdIntegrationsForWorkspace,
+						apiKey,
 						sdkList,
 						mesh,
 					};

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -23,10 +23,7 @@ const {
 	readFileContents,
 	validateAndInterpolateMesh,
 } = require('../../utils');
-const {
-	getMesh,
-	createMesh,
-} = require('../../lib/devConsole');
+const { getMesh, createMesh } = require('../../lib/devConsole');
 
 const { MULTITENANT_GRAPHQL_SERVER_BASE_URL, TMOConstants } = CONSTANTS;
 
@@ -107,10 +104,9 @@ class CreateCommand extends Command {
 
 		if (shouldContinue) {
 			try {
-				const { mesh, apiKey, sdkList} = await createMesh(imsOrgId, projectId, workspaceId, data);
+				const { mesh, apiKey, sdkList } = await createMesh(imsOrgId, projectId, workspaceId, data);
 
 				if (mesh) {
-					
 					this.log(
 						'******************************************************************************************************',
 					);
@@ -128,10 +124,7 @@ class CreateCommand extends Command {
 						this.log('Successfully created API Key %s', apiKey);
 
 						if (sdkList) {
-							this.log(
-								'Successfully subscribed API Key %s to API Mesh service',
-								apiKey,
-							);
+							this.log('Successfully subscribed API Key %s to API Mesh service', apiKey);
 
 							const { meshURL } = await getMesh(imsOrgId, projectId, workspaceId, mesh.meshId);
 							const meshUrl =
@@ -152,10 +145,7 @@ class CreateCommand extends Command {
 								);
 							}
 						} else {
-							this.log(
-								'Unable to subscribe API Key %s to API Mesh service',
-								apiKey,
-							);
+							this.log('Unable to subscribe API Key %s to API Mesh service', apiKey);
 						}
 					} else {
 						this.log('Unable to create API Key');

--- a/src/lib/devConsole.js
+++ b/src/lib/devConsole.js
@@ -241,7 +241,7 @@ const createMesh = async (organizationId, projectId, workspaceId, data) => {
 				};
 			} else {
 				logger.error('API Key credential not found on workspace');
-				
+
 				// try to create a new API key credential
 				credential = await createAPIMeshCredentials(organizationId, projectId, workspaceId);
 				if (credential) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
### Problem:
The Dev Console team plans on introducing a change to the createAPICredential API so that it will not return an existing credential. Instead, it will simply fail with an appropriate error if one already exists. This is a will be a breaking change for the API Mesh CLI plugin.


## How Has This Been Tested?
There are two workflows that need to be tested with this change.

If apiKey is available for a particular workspace, then instead of creating a new one, we use that exiting credential and subscribe that key to the meshService. 
This can be tested by creating a new mesh on an exising workspace

If no apiKey is found for a particular workspace, in that case, we would create a new credential and use that and subscribe to the API mesh service
This workflow can be tested by creating a new workspace in your project and continue with creating a new mesh there

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
