### PR TITLE
Fix inconsistent error response if mesh is missing in get command

### DIFF
--- a/src/commands/api-mesh/get.js
+++ b/src/commands/api-mesh/get.js
@@ -90,6 +90,7 @@ class GetCommand extends Command {
 		} else {
 			this.error(
 				`Unable to get mesh config. No mesh found for Org(${imsOrgId}) -> Project(${projectId}) -> Workspace(${workspaceId}). Please check the details and try again.`,
+				{exit:false}
 			);
 		}
 	}

--- a/src/commands/api-mesh/get.js
+++ b/src/commands/api-mesh/get.js
@@ -87,12 +87,10 @@ class GetCommand extends Command {
 				);
 			}
 		} else {
-				
-				this.error(
-					`Unable to get mesh config. No mesh found for Org(${imsOrgId}) -> Project(${projectId}) -> Workspace(${workspaceId}). Please check the details and try again.`,
-					{exit:false}
-				);
-			
+			this.error(
+				`Unable to get mesh config. No mesh found for Org(${imsOrgId}) -> Project(${projectId}) -> Workspace(${workspaceId}). Please check the details and try again.`,
+				{ exit: false },
+			);
 		}
 	}
 }

--- a/src/commands/api-mesh/get.js
+++ b/src/commands/api-mesh/get.js
@@ -18,7 +18,6 @@ const { ignoreCacheFlag, jsonFlag } = require('../../utils');
 const { getMeshId, getMesh } = require('../../lib/devConsole');
 
 require('dotenv').config();
-
 class GetCommand extends Command {
 	static args = [{ name: 'file' }];
 	static flags = {
@@ -88,10 +87,12 @@ class GetCommand extends Command {
 				);
 			}
 		} else {
-			this.error(
-				`Unable to get mesh config. No mesh found for Org(${imsOrgId}) -> Project(${projectId}) -> Workspace(${workspaceId}). Please check the details and try again.`,
-				{exit:false}
-			);
+				
+				this.error(
+					`Unable to get mesh config. No mesh found for Org(${imsOrgId}) -> Project(${projectId}) -> Workspace(${workspaceId}). Please check the details and try again.`,
+					{exit:false}
+				);
+			
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The ticket https://jira.corp.adobe.com/browse/CEXT-2318 reported the following error while running Get command against a workspace that doesn't have a mesh on it.
![image](https://github.com/adobe/aio-cli-plugin-api-mesh/assets/108254100/41f5ec2a-d8c1-4f97-8f59-30c82014b61f)
The error response is inconsistent whan --json flag is passed with the command.
<!--- Describe your changes in detail -->

Passing the exit false in the error method of the command class fixes the issue. As Oclif directly returning the exit code as 2 and exits the further execution of the program.
![image](https://github.com/adobe/aio-cli-plugin-api-mesh/assets/108254100/7c76bae4-9a11-4a9e-9452-ef10dff2fe2b)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
The tested the case with the --json flag and without the json flag in a workspace that doesnt have a mesh.
<img width="572" alt="image" src="https://github.com/adobe/aio-cli-plugin-api-mesh/assets/108254100/e7eb24bc-a3d8-4f46-afa8-3a383dbdfee2">
<img width="608" alt="image" src="https://github.com/adobe/aio-cli-plugin-api-mesh/assets/108254100/d6d3453b-19c2-4fde-8b2b-b897796ecce0">

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
