### PR TITLE
v3.2.2 - npm publish with previous version of tool

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -18,4 +18,3 @@ jobs:
               with:
                   token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
                   access: 'public'
-                  tag: 'beta'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.2.1-beta.2",
+	"version": "3.2.2",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Republish of `v3.2.1-beta.2` as a stable version `v3.2.2`. See https://github.com/adobe/aio-cli-plugin-api-mesh/pull/116.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CEXT-2672
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
