### PR TITLE
v3.2.3 - updated @adobe-apimesh/mesh-builder version to 1.4.2

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -14,7 +14,8 @@ jobs:
               with:
                   node-version: 18
             - run: yarn install --frozen-lockfile
-            - uses: JS-DevTools/npm-publish@v3
+            - uses: JS-DevTools/npm-publish@v1
               with:
                   token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
                   access: 'public'
+                  tag: 'beta'

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -18,4 +18,3 @@ jobs:
               with:
                   token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
                   access: 'public'
-                  tag: 'beta'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.2.2",
+	"version": "3.2.3",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"
@@ -37,7 +37,7 @@
 		"version": "oclif-dev readme && git add README.md"
 	},
 	"dependencies": {
-		"@adobe-apimesh/mesh-builder": "1.4.0",
+		"@adobe-apimesh/mesh-builder": "1.4.2",
 		"@adobe/aio-cli-lib-console": "^4.0.0",
 		"@adobe/aio-lib-core-config": "^3.0.0",
 		"@adobe/aio-lib-core-logging": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.2.1",
+	"version": "3.2.1-beta.2",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.2.1-beta.2",
+	"version": "3.2.2",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@adobe-apimesh/mesh-builder@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@adobe-apimesh/mesh-builder/-/mesh-builder-1.4.0.tgz#edc593280e4edc3c472e36870948326c46a746d1"
-  integrity sha512-a8Hafd9TOQPuorFUPuqAofJQoLwBO/ADMUa6TMDk1NC/LATUSVd1H+IUar4L2IzD6/aUWBBWv4vEHymknFn/ww==
+"@adobe-apimesh/mesh-builder@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@adobe-apimesh/mesh-builder/-/mesh-builder-1.4.2.tgz#bbe0a24c0668faece7d2918b223afb6fb92078bb"
+  integrity sha512-aTHZ353md/HVHXvk4NJ4qhCqk3nQylpDBLDfB6IiI/pRYf0dthWIF0Pfpu3RGfr6G7R8NbR5/MVrvkqM320UVw==
   dependencies:
     "@fastify/request-context" "^4.1.0"
     eslint "^8.39.0"


### PR DESCRIPTION
To merge updated mesh-builder package into main

## Description

- Updated mesh-builder version to 1.4.2 

## Related Issue

(https://jira.corp.adobe.com/browse/CEXT-2667)

## Motivation and Context

To keep the mesh-builder up to date to latest

## How Has This Been Tested?

By running CLI tests locally 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
