### PR TITLE
Feature/cext 2719 support passing workspace on update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.2.4-beta",
+	"version": "3.2.5-beta",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/commands/api-mesh/__tests__/update.test.js
+++ b/src/commands/api-mesh/__tests__/update.test.js
@@ -52,6 +52,9 @@ describe('update command tests', () => {
 			imsOrgId: selectedOrg.id,
 			projectId: selectedProject.id,
 			workspaceId: selectedWorkspace.id,
+			workspaceName: selectedWorkspace.title,
+			orgName: selectedOrg.name,
+			projectName: selectedProject.title,
 		});
 
 		global.requestId = 'dummy_request_id';
@@ -554,6 +557,9 @@ describe('update command tests', () => {
 		  "1234",
 		  "5678",
 		  "123456789",
+		  "Workspace01",
+		  "ORG01",
+		  "Project01",
 		  "mesh_id",
 		  {
 		    "meshConfig": {

--- a/src/commands/api-mesh/source/__tests__/install.test.js
+++ b/src/commands/api-mesh/source/__tests__/install.test.js
@@ -40,6 +40,8 @@ initSdk.mockResolvedValue({
 	projectId: selectedProject.id,
 	workspaceId: selectedWorkspace.id,
 	workspaceName: selectedWorkspace.title,
+	organizationName: selectedOrg.name,
+	projectName: selectedProject.title,
 });
 initRequestId.mockResolvedValue({});
 promptInput.mockResolvedValueOnce('test-03');
@@ -148,6 +150,8 @@ describe('source:install command tests', () => {
 			selectedProject.id,
 			selectedWorkspace.id,
 			selectedWorkspace.title,
+			selectedOrg.name,
+			selectedProject.title,
 			'dummy_meshId',
 			res,
 		);

--- a/src/commands/api-mesh/source/install.js
+++ b/src/commands/api-mesh/source/install.js
@@ -36,7 +36,14 @@ class InstallCommand extends Command {
 		await initRequestId();
 		logger.info(`RequestId: ${global.requestId}`);
 		const ignoreCache = await flags.ignoreCache;
-		const { imsOrgId, projectId, workspaceId, workspaceName } = await initSdk({ ignoreCache });
+		const {
+			imsOrgId,
+			projectId,
+			workspaceId,
+			organizationName,
+			projectName,
+			workspaceName,
+		} = await initSdk({ ignoreCache });
 		const filepath = flags['variable-file'];
 		let variables = flags.variable
 			? flags.variable.reduce((obj, val) => {
@@ -199,9 +206,18 @@ class InstallCommand extends Command {
 			}
 
 			try {
-				const response = await updateMesh(imsOrgId, projectId, workspaceId, workspaceName, meshId, {
-					meshConfig: mesh.meshConfig,
-				});
+				const response = await updateMesh(
+					imsOrgId,
+					projectId,
+					workspaceId,
+					workspaceName,
+					organizationName,
+					projectName,
+					meshId,
+					{
+						meshConfig: mesh.meshConfig,
+					},
+				);
 
 				this.log('Successfully updated the mesh with the id: %s', meshId);
 

--- a/src/commands/api-mesh/update.js
+++ b/src/commands/api-mesh/update.js
@@ -49,9 +49,11 @@ class UpdateCommand extends Command {
 		const autoConfirmAction = await flags.autoConfirmAction;
 		const envFilePath = await flags.env;
 
-		const { imsOrgId, projectId, workspaceId } = await initSdk({
-			ignoreCache,
-		});
+		const { imsOrgId, projectId, workspaceId, orgName, projectName, workspaceName } = await initSdk(
+			{
+				ignoreCache,
+			},
+		);
 
 		//Input the mesh data from the input file
 		let inputMeshData = await readFileContents(args.file, this, 'mesh');
@@ -112,7 +114,16 @@ class UpdateCommand extends Command {
 
 			if (shouldContinue) {
 				try {
-					const response = await updateMesh(imsOrgId, projectId, workspaceId, meshId, data);
+					const response = await updateMesh(
+						imsOrgId,
+						projectId,
+						workspaceId,
+						workspaceName,
+						orgName,
+						projectName,
+						meshId,
+						data,
+					);
 
 					this.log(
 						'******************************************************************************************************',

--- a/src/lib/devConsole.js
+++ b/src/lib/devConsole.js
@@ -325,7 +325,28 @@ const createMesh = async (
 	}
 };
 
-const updateMesh = async (organizationId, projectId, workspaceId, meshId, data) => {
+/**
+ * Update an API Mesh.
+ * @param {string} organizationId Organization identifier.
+ * @param {string} projectId Project identifier.
+ * @param {string} workspaceId Workspace identifier.
+ * @param {string} workspaceName Workspace Name.
+ * @param {string} orgName Organization name.
+ * @param {string} projectName Project name.
+ * @param {string} meshId Mesh identifier.
+ * @param {unknown} data Mesh configuration data.
+ * @returns {Promise<any>}
+ */
+const updateMesh = async (
+	organizationId,
+	projectId,
+	workspaceId,
+	workspaceName,
+	orgName,
+	projectName,
+	meshId,
+	data,
+) => {
 	const { baseUrl: devConsoleUrl, accessToken, apiKey } = await getDevConsoleConfig();
 	const config = {
 		method: 'put',
@@ -334,6 +355,9 @@ const updateMesh = async (organizationId, projectId, workspaceId, meshId, data) 
 			'Authorization': `Bearer ${accessToken}`,
 			'Content-Type': 'application/json',
 			'x-request-id': global.requestId,
+			'workspaceName': workspaceName,
+			'orgName': orgName,
+			'projectName': projectName,
 		},
 		data: JSON.stringify(data),
 	};


### PR DESCRIPTION
## Description

Update functionality should mirror create functionality to account for changes.

## Related Issue

CEXT-2719

## How Has This Been Tested?

- Link plugin in aio
- Interactions with sms should include optional org, project, workspace information.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
