### PR TITLE
Update publish-to-npm workflow to accommodate alpha and beta packages

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,21 +1,71 @@
 name: publish-to-npm
 on:
-    pull_request:
-        types: [closed]
-        branches:
-            - main
+  pull_request:
+    types: [ closed ]
+    branches:
+      - main
+      - develop
+      - epic/**
 jobs:
-    publish:
-        if: github.repository == 'adobe/aio-cli-plugin-api-mesh'
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: 18
-            - run: yarn install --frozen-lockfile
-            - uses: JS-DevTools/npm-publish@v1
-              with:
-                  token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
-                  access: 'public'
-                  tag: 'alpha'
+  publish:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Yarn install
+        run: yarn install --frozen-lockfile
+
+      - name: Get version from package.json
+        id: get_version
+        run: | 
+          version=$(jq -r '.version' package.json)
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "Read version $version from package.json"
+
+      - name: Verify version corresponds to branch
+        id: verify_version
+        run: |
+          target_branch="${GITHUB_REF#refs/heads/}"
+          version_tag=""
+          
+          if [ "$target_branch" == "main" ]; then
+            version_tag="latest"
+          
+          elif [ "$target_branch" == "develop" ]; then
+            if [[ "${{ steps.get_version.outputs.version }}" =~ beta ]]; then
+              version_tag="beta"
+            else
+              echo "Will not publish. Version on branch \"$target_branch\" is not beta.";
+              exit 0;
+            fi
+          
+          elif [[ $target_branch == epic/* ]]; then
+            if [[ "${{ steps.get_version.outputs.version }}" =~ alpha ]]; then
+              version_tag="alpha"
+            else 
+              echo "Will not publish. Version on branch \"$target_branch\" is not alpha.";
+              exit 0;
+            fi
+          
+          else
+            echo "Will not publish. Branch \"$target_branch\" is not designated for publish.";
+            exit 0;
+          fi
+          
+          echo "version_tag=$version_tag" >> $GITHUB_OUTPUT;
+          echo "Will publish version ${{ steps.get_version.outputs.version }} as $version_tag"
+
+      - name: Publish to npm
+        if: ${{ steps.verify_version.outputs.version_tag != '' }}
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
+          access: 'public'
+          tag: ${{ steps.verify_version.outputs.version_tag }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
### Problem
Currently, we don't have the ability to publish the CLI plugin to npm unless we merge our code changes to `main`.  In the case of testing on the `develop` branch, as well as on epic branches, we don't want to have to merge incomplete changes to `main` for the sake of a publish. It's worth noting that most team members don't have permission to publish directly to the Adobe organization from their local machine, nor do we want to get into the practice of doing so.

Additionally, we don't have a dynamic way to add a tag to a publish _even if we DID want to merge to main_. The current process involves committing the tag in the workflow file and later reverting it. Failure to add the tag results the in publish being tagged as `latest` and automatically being installed on the next AIO update (which is bad). 

### Propsal
- Any PR merge to the `develop` branch will attempt a publish as a `beta` package 
  - consider that this is usually one step before release
  - we can change this to any `release/*` branch if we adopt that workflow
- Any PR merge to an `epic/*` branch will attempt a publish as an `alpha` package 
  - consider that there is likely still active development happening

### Caveat
Opening up publishing from branches other than `main` can be error prone with regard to versioning (we don't want to publish the wrong branch as a `latest` version). 

As such, this PR enforces the following:
- the version in the `package.json` file MUST include the appropriate suffix in accordance to the tag it will be published with
- the publish automatically assumes the proper tag (`alpha`, `beta`, `latest`) depending on the branch the PR was merged to

### Example
A PR merge to the `epic/cloudflare` branch must be versioned as `x.x.x-alpha[.x]`, and will automatically assume the `alpha` tag when published. 
- Failure to do so will result in the `Publish to npm` step of the workflow being skipped. 
- The current behavior of a pre-existing version in npm failing to re-publish will remain unchanged.

<!--- Describe your changes in detail -->


## How Has This Been Tested?
Manually triggering the workflow. 

Additional testing will be performed as the workflow is merged to various branches.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="1351" alt="image" src="https://github.com/adobe/aio-cli-plugin-api-mesh/assets/44038475/6e506b1f-9d97-4665-a8a4-1bc3f3e3c41d">

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
