### PR TITLE
Cext 3162 legacy mesh label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.3.0-beta",
+	"version": "3.3.0-beta.1",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/commands/api-mesh/status.js
+++ b/src/commands/api-mesh/status.js
@@ -24,7 +24,6 @@ class StatusCommand extends Command {
 
 		const { flags } = await this.parse(StatusCommand);
 		const ignoreCache = await flags.ignoreCache;
-
 		const { imsOrgId, imsOrgCode, projectId, workspaceId, workspaceName } = await initSdk({
 			ignoreCache,
 		});
@@ -44,28 +43,33 @@ class StatusCommand extends Command {
 			try {
 				const { showCloudflareURL: showEdgeMeshUrl } = await getTenantFeatures(imsOrgCode);
 				const mesh = await getMesh(imsOrgId, projectId, workspaceId, workspaceName, meshId);
+				const meshLabel = showEdgeMeshUrl ? `${chalk.bold('Legacy Mesh:')}` : 'Your mesh';
+
 				this.log(
 					'******************************************************************************************************',
 				);
 				switch (mesh.meshStatus) {
 					case 'success':
-						this.log(`${chalk.bold(`Legacy Mesh:`)} has been successfully built.`);
+						this.log(`${meshLabel} has been successfully built.`);
 						break;
 					case 'pending':
-						this.log(`${chalk.bold(`Legacy Mesh:`)} is awaiting processing.`);
+						this.log(`${meshLabel} is awaiting processing.`);
 						break;
 					case 'building':
 						this.log(
-							`${chalk.bold(
-								`Legacy Mesh:`,
-							)} is currently being provisioned. Please wait a few minutes before checking again.`,
+							`${meshLabel} is currently being provisioned. Please wait a few minutes before checking again.`,
 						);
 						break;
 					case 'error':
-						this.log(`${chalk.bold(`Legacy Mesh:`)} build has errors.`);
+						this.log(
+							showEdgeMeshUrl
+								? `${meshLabel} build has errors.`
+								: `${meshLabel} errored out with the following error.`,
+						);
 						this.log(mesh.error);
 						break;
 				}
+
 				if (showEdgeMeshUrl) {
 					if (mesh.meshStatus == 'error') {
 						this.log(`${chalk.bold(`Edge Mesh:`)} build has errors.`);
@@ -77,6 +81,7 @@ class StatusCommand extends Command {
 							workspaceId,
 							meshId,
 						);
+
 						switch (String(meshDeployments.status).toLowerCase()) {
 							case 'success':
 								this.log(`${chalk.bold(`Edge Mesh:`)} has been successfully built.`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR includes following changes:

1. Removal of the "Legacy Mesh" label from the status command when edge mesh functionality is not enabled (_See  [CEXT-3162](https://jira.corp.adobe.com/browse/CEXT-3162_)
2. Updating the edge mesh status to match that of the legacy mesh during the SMS build phase (since this status is shared)
3. Minor refactor
4. Increase of the beta version

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/CEXT-3162

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
- Keep messaging consistent with the existing functionality as "Legacy Mesh" is irrelevant to non private-beta customers.
- Ensure edge mesh status is accurate.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Loaded the new CLI plugin locally using the `aio plugins link .` command within the bugfix branch.
Tested all status combinations.
Will run CLI tests (which inspect status message) with feature-flag disabled

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
### With feature flag **enabled**
<img width="873" alt="Screenshot 2024-05-03 at 11 10 53 AM" src="https://github.com/adobe/aio-cli-plugin-api-mesh/assets/44038475/1d35b4d9-e71d-476a-9492-b9ffba2527fe">

### With feature flag **disabled** (INCORRECT BEHAVIOR - BEFORE FIX)
<img width="905" alt="Screenshot 2024-05-03 at 11 10 07 AM" src="https://github.com/adobe/aio-cli-plugin-api-mesh/assets/44038475/937fdb0c-5b5b-4c93-b997-9e834a0beb20">
<img width="867" alt="Screenshot 2024-05-03 at 11 10 00 AM" src="https://github.com/adobe/aio-cli-plugin-api-mesh/assets/44038475/79fcbc2c-2533-4792-ab5d-c8e02ee17350">

### With feature flag **disabled** (CORRECT BEHAVIOR - AFTER FIX)
<img width="873" alt="Screenshot 2024-05-03 at 11 10 53 AM" src="https://github.com/adobe/aio-cli-plugin-api-mesh/assets/44038475/1d35b4d9-e71d-476a-9492-b9ffba2527fe">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
