### PR TITLE
Cext 3114

### DIFF
--- a/src/commands/__fixtures__/sample_secrets_mesh.json
+++ b/src/commands/__fixtures__/sample_secrets_mesh.json
@@ -1,0 +1,18 @@
+{
+	"meshConfig": {
+		"sources": [
+			{
+				"name": "Commerce",
+				"handler": {
+					"graphql": {
+						"endpoint": "https://venia.magento.com/graphql",
+						"operationHeaders": {
+							"Authorization": "{context.secrets.Token}"
+						},
+						"useGETForQueries": true
+					}
+				}
+			}
+		]
+	}
+}

--- a/src/commands/__fixtures__/secrets_invalid.yaml
+++ b/src/commands/__fixtures__/secrets_invalid.yaml
@@ -1,0 +1,3 @@
+HOME: 'home'
+TOKEN: "dummy-token"
+TOKEN: "dummy-token-duplicate"

--- a/src/commands/__fixtures__/secrets_valid.yaml
+++ b/src/commands/__fixtures__/secrets_valid.yaml
@@ -1,0 +1,2 @@
+HOME: 'home'
+TOKEN: "dummy-token"

--- a/src/commands/__fixtures__/secrets_with_batch_variables.yaml
+++ b/src/commands/__fixtures__/secrets_with_batch_variables.yaml
@@ -1,0 +1,4 @@
+HOME: 'home'
+TOKEN: "dummy-token"
+batchHome: '$HOME'
+USER: '${USER}'

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -1751,4 +1751,90 @@ describe('create command tests', () => {
 		]
 	`);
 	});
+
+	test('should return error if mesh has placeholders and the provided secrets file is invalid', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_secrets_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: Promise.resolve(true),
+				secrets: 'src/commands/__fixtures__/secrets_invalid.yaml',
+			},
+		});
+
+		const runResult = CreateCommand.run();
+
+		await expect(runResult).rejects.toEqual(
+			new Error('Unable to import secrets. Please check the file and try again.'),
+		);
+
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Unable to import secrets. Please check the file and try again.",
+		  ],
+		]
+	`);
+	});
+
+	test('should return error if mesh has placeholders and the provided secrets file is not yaml or yml', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_secrets_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: Promise.resolve(true),
+				secrets: 'src/commands/__fixtures__/.secrets_file.env',
+			},
+		});
+
+		const runResult = CreateCommand.run();
+
+		await expect(runResult).rejects.toEqual(
+			new Error('Unable to import secrets. Please check the file and try again.'),
+		);
+
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Unable to import secrets. Please check the file and try again.",
+		  ],
+		]
+	`);
+	});
+
+	test('should successfully create a mesh if provided secrets file is valid', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_secrets_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: Promise.resolve(true),
+				secrets: 'src/commands/__fixtures__/secrets_valid.yaml',
+			},
+		});
+
+		const runResult = await CreateCommand.run();
+		expect(runResult).toMatchInlineSnapshot(`
+		{
+		  "apiKey": "dummy_api_key",
+		  "mesh": {
+		    "meshConfig": {
+		      "sources": [
+		        {
+		          "handler": {
+		            "graphql": {
+		              "endpoint": "<gql_endpoint>",
+		            },
+		          },
+		          "name": "<api_name>",
+		        },
+		      ],
+		    },
+		    "meshId": "dummy_mesh_id",
+		  },
+		  "sdkList": [
+		    "dummy_service",
+		  ],
+		}
+	`);
+	});
 });

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -1926,4 +1926,41 @@ describe('create command tests', () => {
 		}
 	`);
 	});
+
+	test('should pass if ran against darwin(macOS) platform with batch variables', async () => {
+		platformSpy.mockReturnValue('darwin');
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_secrets_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: Promise.resolve(true),
+				secrets: 'src/commands/__fixtures__/secrets_with_batch_variables.yaml',
+			},
+		});
+
+		const runResult = await CreateCommand.run();
+		expect(runResult).toMatchInlineSnapshot(`
+		{
+		  "apiKey": "dummy_api_key",
+		  "mesh": {
+		    "meshConfig": {
+		      "sources": [
+		        {
+		          "handler": {
+		            "graphql": {
+		              "endpoint": "<gql_endpoint>",
+		            },
+		          },
+		          "name": "<api_name>",
+		        },
+		      ],
+		    },
+		    "meshId": "dummy_mesh_id",
+		  },
+		  "sdkList": [
+		    "dummy_service",
+		  ],
+		}
+	`);
+	});
 });

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -1778,7 +1778,7 @@ describe('create command tests', () => {
 		await expect(runResult).rejects.toEqual(
 			new Error('Unable to import secrets. Please check the file and try again.'),
 		);
-		
+
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [

--- a/src/utils.js
+++ b/src/utils.js
@@ -459,10 +459,10 @@ async function parseSecrets(secretsContent) {
 		};
 		const compiledSecretsFileContent = parseEnv(secretsContent, envParserConfig);
 		const parsedSecrets = YAML.parse(compiledSecretsFileContent);
-		return parsedSecrets;
+
+		return YAML.stringify(parsedSecrets);
 	} catch (err) {
-		secretsParseError = getSecretsYamlParseError(err);
-		throw new Error(chalk.red(secretsParseError));
+		throw new Error(chalk.red(getSecretsYamlParseError(err)));
 	}
 }
 
@@ -472,12 +472,12 @@ async function parseSecrets(secretsContent) {
  * @param error errors from YAML.parse
  */
 function getSecretsYamlParseError(error) {
-	if(error.code === 'BAD_INDENT') {
-        return "Bad indentation error occurred while parsing YAML data: " + error.message;
-	} else if(error.code === 'DUPLICATE_KEY') {
-        return "Duplicate Keys found while parsing YARN data: " + error.message;
+	if (error.code === 'BAD_INDENT') {
+		return 'Bad indentation error occurred while parsing YAML data: ' + error.message;
+	} else if (error.code === 'DUPLICATE_KEY') {
+		return 'Duplicate Keys found while parsing YARN data: ' + error.message;
 	} else {
-		return "An unexpected error occurred: " + error.message;
+		return 'An unexpected error occurred: ' + error.message;
 	}
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -465,13 +465,13 @@ async function parseSecrets(secretsContent) {
 		//check if secrets file is empty
 		if (!parsedSecrets) {
 			throw new Error(
-				chalk.red('Please check if your secrets YAML file is not empty and is valid.'),
+				chalk.red('Invalid YAML file contents. Please verify and try again.'),
 			);
 		}
 		//check if parsedSecrets is string and not in k:v pair
 		if (typeof parsedSecrets === 'string') {
 			throw new Error(
-				chalk.red('Please provide a valid YAML in key:value format and not as string.'),
+				chalk.red('Please provide a valid YAML in key:value format.'),
 			);
 		}
 		const secretsYamlString = YAML.stringify(parsedSecrets);
@@ -488,11 +488,11 @@ async function parseSecrets(secretsContent) {
  */
 function getSecretsYamlParseError(error) {
 	if (error.code === 'BAD_INDENT') {
-		return 'Bad indentation error occurred while parsing YAML data: ' + error.message;
+		return 'Invalid YAML - Bad Indentation: ' + error.message;
 	} else if (error.code === 'DUPLICATE_KEY') {
-		return 'Duplicate Keys found while parsing YARN data: ' + error.message;
+		return 'Invalid YAML - Found Duplicate Keys: ' + error.message;
 	} else {
-		return 'An unexpected error occurred: ' + error.message;
+		return 'Unexpected Error: ' + error.message;
 	}
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -432,8 +432,8 @@ async function interpolateSecrets(secretsFilePath, command) {
 		const secretsContent = await readFileContents(secretsFilePath, command, 'secrets');
 
 		// Check if environment variables are used in the file content
-		if (os.platform() === 'win32' && /(\$[a-zA-Z_][a-zA-Z0-9_]*)/.test(secretsContent)) {
-			throw new Error('Batch variables are not supported in YAML files on Windows.');
+		if (os.platform() === 'win32' && /\$({)?[a-zA-Z_][a-zA-Z0-9_]*}?/.test(secretsContent)) {
+			throw new Error(chalk.red('Batch variables are not supported in YAML files on Windows.'));
 		}
 		const secrets = await parseSecrets(secretsContent);
 		return secrets;

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,7 @@ const dotenv = require('dotenv');
 const YAML = require('yaml');
 const parseEnv = require('envsub/js/envsub-parser');
 const os = require('os');
+const chalk = require('chalk');
 
 /**
  * @returns returns the root directory of the project
@@ -460,8 +461,23 @@ async function parseSecrets(secretsContent) {
 		const parsedSecrets = YAML.parse(compiledSecretsFileContent);
 		return parsedSecrets;
 	} catch (err) {
-		logger.error(err);
-		throw new Error(err.message);
+		secretsParseError = getSecretsYamlParseError(err);
+		throw new Error(chalk.red(secretsParseError));
+	}
+}
+
+/**
+ * This function returns user friendly errors that occurs while YAML.parse
+ *
+ * @param error errors from YAML.parse
+ */
+function getSecretsYamlParseError(error) {
+	if(error.code === 'BAD_INDENT') {
+        return "Bad indentation error occurred while parsing YAML data: " + error.message;
+	} else if(error.code === 'DUPLICATE_KEY') {
+        return "Duplicate Keys found while parsing YARN data: " + error.message;
+	} else {
+		return "An unexpected error occurred: " + error.message;
 	}
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -464,15 +464,11 @@ async function parseSecrets(secretsContent) {
 		const parsedSecrets = YAML.parse(compiledSecretsFileContent);
 		//check if secrets file is empty
 		if (!parsedSecrets) {
-			throw new Error(
-				chalk.red('Invalid YAML file contents. Please verify and try again.'),
-			);
+			throw new Error(chalk.red('Invalid YAML file contents. Please verify and try again.'));
 		}
 		//check if parsedSecrets is string and not in k:v pair
 		if (typeof parsedSecrets === 'string') {
-			throw new Error(
-				chalk.red('Please provide a valid YAML in key:value format.'),
-			);
+			throw new Error(chalk.red('Please provide a valid YAML in key:value format.'));
 		}
 		const secretsYamlString = YAML.stringify(parsedSecrets);
 		return secretsYamlString; //TODO: here we will encrypt secrets and return.


### PR DESCRIPTION
Secrets file validation

## Description

This PR is related to secrets file validation in windows and unix environment.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-3114

## Motivation and Context

* Validate secrets file in various aspects and throw relevant messages.

## How Has This Been Tested?

Loaded the new CLI plugin locally using the `aio plugins link .` command against branch.
Tested all status combinations.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
