### PR TITLE
Secrets encryption from CLI

### DIFF
--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -2124,7 +2124,7 @@ describe('create command tests', () => {
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Something went wrong in secerts encryption. Invalid publicKey provided.",
+		    "Unable to encrypt secerts. Invalid Public Key.",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -2102,4 +2102,31 @@ describe('create command tests', () => {
 		}
 	`);
 	});
+
+	test('should return error if secrets file is valid but public key for encryption is empty', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_secrets_mesh.json' },
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: Promise.resolve(true),
+				secrets: 'src/commands/__fixtures__/secrets_valid.yaml',
+			},
+		});
+		getPublicEncryptionKey.mockResolvedValue('');
+
+		crypto.randomBytes.mockReturnValueOnce(mockAesKey).mockReturnValueOnce(mockIv);
+		crypto.createCipheriv.mockReturnValueOnce(mockCipher);
+
+		const runResult = CreateCommand.run();
+		await expect(runResult).rejects.toEqual(
+			new Error('Unable to import secrets. Please check the file and try again.'),
+		);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Something went wrong in secerts encryption. Invalid publicKey provided.",
+		  ],
+		]
+	`);
+	});
 });

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const mockConsoleCLIInstance = {};
+const crypto = require('crypto');
 
 jest.mock('axios');
 jest.mock('@adobe/aio-lib-ims');
@@ -44,6 +45,7 @@ const {
 	createAPIMeshCredentials,
 	subscribeCredentialToMeshService,
 	getTenantFeatures,
+	getPublicEncryptionKey,
 } = require('../../../lib/devConsole');
 
 const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' };
@@ -74,6 +76,7 @@ jest.mock('chalk', () => ({
 	red: jest.fn(text => text), // Return the input text without any color formatting
 	bold: jest.fn(text => text),
 }));
+jest.mock('crypto');
 
 let logSpy = null;
 let errorLogSpy = null;
@@ -82,6 +85,15 @@ let platformSpy = null;
 
 const mockIgnoreCacheFlag = Promise.resolve(true);
 const mockAutoApproveAction = Promise.resolve(false);
+
+// Mock randomBytes for aesKey and iv
+const mockAesKey = Buffer.from('mockAesKey');
+const mockIv = Buffer.from('mockIv');
+const mockEncryptedAesKey = Buffer.from('mockEncryptedAesKey');
+const mockCipher = {
+	update: jest.fn().mockReturnValueOnce('mockEncryptedData'),
+	final: jest.fn().mockReturnValueOnce(''),
+};
 
 describe('create command tests', () => {
 	beforeEach(() => {
@@ -127,6 +139,7 @@ describe('create command tests', () => {
 			showCloudflareURL: false,
 		});
 
+		getPublicEncryptionKey.mockResolvedValue('dummy_public_key');
 		global.requestId = 'dummy_request_id';
 
 		logSpy = jest.spyOn(CreateCommand.prototype, 'log');
@@ -1945,6 +1958,10 @@ describe('create command tests', () => {
 			},
 		});
 
+		crypto.randomBytes.mockReturnValueOnce(mockAesKey).mockReturnValueOnce(mockIv);
+		crypto.createCipheriv.mockReturnValueOnce(mockCipher);
+		crypto.publicEncrypt.mockReturnValueOnce(mockEncryptedAesKey);
+
 		const runResult = await CreateCommand.run();
 		expect(runResult).toMatchInlineSnapshot(`
 		{
@@ -2015,6 +2032,10 @@ describe('create command tests', () => {
 			},
 		});
 
+		crypto.randomBytes.mockReturnValueOnce(mockAesKey).mockReturnValueOnce(mockIv);
+		crypto.createCipheriv.mockReturnValueOnce(mockCipher);
+		crypto.publicEncrypt.mockReturnValueOnce(mockEncryptedAesKey);
+
 		const runResult = await CreateCommand.run();
 		expect(runResult).toMatchInlineSnapshot(`
 		{
@@ -2051,6 +2072,10 @@ describe('create command tests', () => {
 				secrets: 'src/commands/__fixtures__/secrets_with_batch_variables.yaml',
 			},
 		});
+
+		crypto.randomBytes.mockReturnValueOnce(mockAesKey).mockReturnValueOnce(mockIv);
+		crypto.createCipheriv.mockReturnValueOnce(mockCipher);
+		crypto.publicEncrypt.mockReturnValueOnce(mockEncryptedAesKey);
 
 		const runResult = await CreateCommand.run();
 		expect(runResult).toMatchInlineSnapshot(`

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -25,7 +25,7 @@ const {
 	validateAndInterpolateMesh,
 	interpolateSecrets,
 	validateSecretsFile,
-	encryptSecret,
+	encryptSecrets,
 } = require('../../utils');
 const { createMesh, getTenantFeatures, getPublicEncryptionKey } = require('../../lib/devConsole');
 const { buildEdgeMeshUrl, buildMeshUrl } = require('../../urlBuilder');
@@ -113,9 +113,9 @@ class CreateCommand extends Command {
 		if (secretsFilePath) {
 			try {
 				await validateSecretsFile(secretsFilePath);
-				const publicKey = await getPublicEncryptionKey(imsOrgCode);
 				const secretsData = await interpolateSecrets(secretsFilePath, this);
-				const encryptedSecrets = await encryptSecret(publicKey, secretsData);
+				const publicKey = await getPublicEncryptionKey(imsOrgCode);
+				const encryptedSecrets = await encryptSecrets(publicKey, secretsData);
 				data.secrets = encryptedSecrets;
 			} catch (err) {
 				this.log(err.message);

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -25,8 +25,9 @@ const {
 	validateAndInterpolateMesh,
 	interpolateSecrets,
 	validateSecretsFile,
+	encryptSecret,
 } = require('../../utils');
-const { createMesh, getTenantFeatures } = require('../../lib/devConsole');
+const { createMesh, getTenantFeatures, getPublicEncryptionKey } = require('../../lib/devConsole');
 const { buildEdgeMeshUrl, buildMeshUrl } = require('../../urlBuilder');
 
 class CreateCommand extends Command {
@@ -112,7 +113,10 @@ class CreateCommand extends Command {
 		if (secretsFilePath) {
 			try {
 				await validateSecretsFile(secretsFilePath);
-				data.secrets = await interpolateSecrets(secretsFilePath, this);
+				const publicKey = await getPublicEncryptionKey(imsOrgCode);
+				const secretsData = await interpolateSecrets(secretsFilePath, this);
+				const encryptedSecrets = await encryptSecret(publicKey, secretsData);
+				data.secrets = encryptedSecrets;
 			} catch (err) {
 				this.log(err.message);
 				this.error('Unable to import secrets. Please check the file and try again.');

--- a/src/commands/api-mesh/update.js
+++ b/src/commands/api-mesh/update.js
@@ -24,7 +24,7 @@ const {
 	getFilesInMeshConfig,
 	interpolateSecrets,
 	validateSecretsFile,
-	encryptSecret,
+	encryptSecrets,
 } = require('../../utils');
 const { getMeshId, updateMesh, getPublicEncryptionKey } = require('../../lib/devConsole');
 
@@ -119,9 +119,9 @@ class UpdateCommand extends Command {
 		if (secretsFilePath) {
 			try {
 				await validateSecretsFile(secretsFilePath);
-				const publicKey = await getPublicEncryptionKey(imsOrgCode);
 				const secretsData = await interpolateSecrets(secretsFilePath, this);
-				const encryptedSecrets = await encryptSecret(publicKey, secretsData);
+				const publicKey = await getPublicEncryptionKey(imsOrgCode);
+				const encryptedSecrets = await encryptSecrets(publicKey, secretsData);
 				data.secrets = encryptedSecrets;
 			} catch (err) {
 				this.log(err.message);

--- a/src/commands/api-mesh/update.js
+++ b/src/commands/api-mesh/update.js
@@ -24,8 +24,9 @@ const {
 	getFilesInMeshConfig,
 	interpolateSecrets,
 	validateSecretsFile,
+	encryptSecret,
 } = require('../../utils');
-const { getMeshId, updateMesh } = require('../../lib/devConsole');
+const { getMeshId, updateMesh, getPublicEncryptionKey } = require('../../lib/devConsole');
 
 class UpdateCommand extends Command {
 	static args = [{ name: 'file' }];
@@ -54,11 +55,17 @@ class UpdateCommand extends Command {
 		const envFilePath = await flags.env;
 		const secretsFilePath = await flags.secrets;
 
-		const { imsOrgId, projectId, workspaceId, orgName, projectName, workspaceName } = await initSdk(
-			{
-				ignoreCache,
-			},
-		);
+		const {
+			imsOrgId,
+			imsOrgCode,
+			projectId,
+			workspaceId,
+			orgName,
+			projectName,
+			workspaceName,
+		} = await initSdk({
+			ignoreCache,
+		});
 
 		//Input the mesh data from the input file
 		let inputMeshData = await readFileContents(args.file, this, 'mesh');
@@ -112,7 +119,10 @@ class UpdateCommand extends Command {
 		if (secretsFilePath) {
 			try {
 				await validateSecretsFile(secretsFilePath);
-				data.secrets = await interpolateSecrets(secretsFilePath, this);
+				const publicKey = await getPublicEncryptionKey(imsOrgCode);
+				const secretsData = await interpolateSecrets(secretsFilePath, this);
+				const encryptedSecrets = await encryptSecret(publicKey, secretsData);
+				data.secrets = encryptedSecrets;
 			} catch (err) {
 				this.log(err.message);
 				this.error('Unable to import secrets. Please check the file and try again.');

--- a/src/lib/devConsole.js
+++ b/src/lib/devConsole.js
@@ -998,9 +998,9 @@ const getPublicEncryptionKey = async organizationCode => {
 		logger.info('Response from GET %s', response.status);
 		if (response.status == 200) {
 			let publicKey = '';
-			logger.info(`Public secrets : ${objToString(response, ['data'])}`);
+			logger.info(`Public key for encryption: ${objToString(response, ['data'])}`);
 			if (response.data.publicKey) {
-				publicKey = response.data.publicKey.replace(/\\n/g, '\n');
+				publicKey = response.data.publicKey.replace(/\\n/g, '\n');//correcting public key format
 			}
 			return publicKey;
 		} else {

--- a/src/lib/devConsole.js
+++ b/src/lib/devConsole.js
@@ -1005,11 +1005,11 @@ const getPublicEncryptionKey = async organizationCode => {
 			return publicKey;
 		} else {
 			let errorMessage = `Failed to load encryption keys. Please contact support.`;
-			logger.error(`${errorMessage}. Received ${response.status} response instead of 200`);
+			logger.error(`${errorMessage}. Received ${response.status}, expected 200`);
 			throw new Error(chalk.red(errorMessage));
 		}
 	} catch (error) {
-		let errorMessage = `Something went wrong in secerts encryption. Please try after some time.`;
+		let errorMessage = `Something went wrong while encrypting secrets. Please try again.`;
 		logger.error(errorMessage);
 		throw new Error(chalk.red(errorMessage));
 	}

--- a/src/lib/devConsole.js
+++ b/src/lib/devConsole.js
@@ -1000,7 +1000,7 @@ const getPublicEncryptionKey = async organizationCode => {
 			let publicKey = '';
 			logger.info(`Public key for encryption: ${objToString(response, ['data'])}`);
 			if (response.data.publicKey) {
-				publicKey = response.data.publicKey.replace(/\\n/g, '\n');//correcting public key format
+				publicKey = response.data.publicKey.replace(/\\n/g, '\n'); //correcting public key format
 			}
 			return publicKey;
 		} else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -500,6 +500,11 @@ function getSecretsYamlParseError(error) {
  * @param secrets Secrets Data that needs encryption
  */
 async function encryptSecret(publicKey, secrets) {
+	if (!publicKey || typeof publicKey !== 'string' || !publicKey.trim()) {
+		throw new Error(
+			chalk.red('Something went wrong in secerts encryption. Invalid publicKey provided.'),
+		);
+	}
 	try {
 		// Generate a random AES key and IV
 		const aesKey = crypto.randomBytes(32); // 256-bit key for AES-256

--- a/src/utils.js
+++ b/src/utils.js
@@ -499,11 +499,9 @@ function getSecretsYamlParseError(error) {
  * @param publicKey Public key for (AES + RSA) encryption
  * @param secrets Secrets Data that needs encryption
  */
-async function encryptSecret(publicKey, secrets) {
+async function encryptSecrets(publicKey, secrets) {
 	if (!publicKey || typeof publicKey !== 'string' || !publicKey.trim()) {
-		throw new Error(
-			chalk.red('Something went wrong in secerts encryption. Invalid publicKey provided.'),
-		);
+		throw new Error(chalk.red('Unable to encrypt secerts. Invalid Public Key.'));
 	}
 	try {
 		// Generate a random AES key and IV
@@ -529,8 +527,8 @@ async function encryptSecret(publicKey, secrets) {
 		};
 		return JSON.stringify(encryptedPackage);
 	} catch (error) {
-		logger.error('Error generating AES key, IV OR encryption package:', error.message);
-		throw new Error(chalk.red(`Failed to generate encryption parameters. Please try again.`));
+		logger.error('Unable to encrypt secrets. Please try again. :', error.message);
+		throw new Error(`Unable to encrypt secerts. ${error.message}`);
 	}
 }
 
@@ -551,5 +549,5 @@ module.exports = {
 	secretsFlag,
 	interpolateSecrets,
 	validateSecretsFile,
-	encryptSecret,
+	encryptSecrets,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -496,7 +496,7 @@ function getSecretsYamlParseError(error) {
 /**
  * Performs hybrid encryption of secrets(AES + RSA)
  *
- * @param publicKey Public key for RSA encryption
+ * @param publicKey Public key for (AES + RSA) encryption
  * @param secrets Secrets Data that needs encryption
  */
 async function encryptSecret(publicKey, secrets) {
@@ -522,7 +522,6 @@ async function encryptSecret(publicKey, secrets) {
 			key: encryptedAesKey.toString('base64'),
 			data: encryptedData,
 		};
-		console.log(JSON.stringify(encryptedPackage));
 		return JSON.stringify(encryptedPackage);
 	} catch (error) {
 		logger.error('Error generating AES key, IV OR encryption package:', error.message);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR is to encrypt secrets data from CLI. Whenever a `create` OR `update` command will be executed with `--secrets` followed by a secrets yaml file, we need to encrypt the secrets data before sending it over.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-3188
(point 3)

## Motivation and Context

This change is required for secrets encryption.

## How Has This Been Tested?

aio plugins link . in this PR branch, make sure the endpoint returns the public key
aio api-mesh create mesh.json --secrets mysecrets.yaml
aio api-mesh update mesh.json --secrets mysecrets.yaml

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
