### PR TITLE
Use dotenv parser to validate env for interpolation

### DIFF
--- a/src/commands/__fixtures__/env_invalid
+++ b/src/commands/__fixtures__/env_invalid
@@ -1,8 +1,2 @@
-#Duplicate Keys
-key1='value1'
-key1='value2'
-#Incorrect format 
-key2=='value3'
-key3
-key4='value4
-key5='value5'
+#Missing value
+key1

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -716,7 +716,7 @@ describe('create command tests', () => {
 	`);
 	});
 
-	test('should return error if mesh has placeholders and the provided env file is invalid', async () => {
+	test('should return error if mesh has placeholders and the provided env file is invalid and parsed to {}', async () => {
 		parseSpy.mockResolvedValueOnce({
 			args: { file: 'src/commands/__fixtures__/sample_mesh_with_placeholder' },
 			flags: {
@@ -730,14 +730,17 @@ describe('create command tests', () => {
 
 		await expect(runResult).rejects.toEqual(
 			new Error(
-				"Issue in src/commands/__fixtures__/env_invalid file - Duplicate key << key1 >> on line 3,Invalid format for key/value << key2=='value3' >> on line 5,Invalid format << key3 >> on line 6,Invalid format for key/value << key4='value4 >> on line 7",
+				'Issue in src/commands/__fixtures__/env_invalid file - Interpolated mesh is not a valid JSON. Please check the generated json file.',
 			),
 		);
 
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Issue in src/commands/__fixtures__/env_invalid file - Duplicate key << key1 >> on line 3,Invalid format for key/value << key2=='value3' >> on line 5,Invalid format << key3 >> on line 6,Invalid format for key/value << key4='value4 >> on line 7",
+		    "Interpolated mesh is not a valid JSON. Please check the generated json file.",
+		  ],
+		  [
+		    "Issue in src/commands/__fixtures__/env_invalid file - Interpolated mesh is not a valid JSON. Please check the generated json file.",
 		  ],
 		]
 	`);
@@ -761,13 +764,18 @@ describe('create command tests', () => {
 
 		const runResult = CreateCommand.run();
 		await expect(runResult).rejects.toEqual(
-			new Error('The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2'),
+			new Error(
+				'Issue in src/commands/__fixtures__/env_valid file - The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2',
+			),
 		);
 
 		await expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
 		    "The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2",
+		  ],
+		  [
+		    "Issue in src/commands/__fixtures__/env_valid file - The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2",
 		  ],
 		]
 	`);
@@ -795,13 +803,18 @@ describe('create command tests', () => {
 
 		const runResult = CreateCommand.run();
 		await expect(runResult).rejects.toEqual(
-			new Error('Interpolated mesh is not a valid JSON. Please check the generated json file.'),
+			new Error(
+				'Issue in src/commands/__fixtures__/env_valid file - Interpolated mesh is not a valid JSON. Please check the generated json file.',
+			),
 		);
 
 		await expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
 		    "Interpolated mesh is not a valid JSON. Please check the generated json file.",
+		  ],
+		  [
+		    "Issue in src/commands/__fixtures__/env_valid file - Interpolated mesh is not a valid JSON. Please check the generated json file.",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/run.test.js
+++ b/src/commands/api-mesh/__tests__/run.test.js
@@ -251,17 +251,20 @@ describe('run command tests', () => {
 
 		await expect(runResult).rejects.toEqual(
 			new Error(
-				"Issue in src/commands/__fixtures__/env_invalid file - Duplicate key << key1 >> on line 3,Invalid format for key/value << key2=='value3' >> on line 5,Invalid format << key3 >> on line 6,Invalid format for key/value << key4='value4 >> on line 7",
+				'Issue in src/commands/__fixtures__/env_invalid file - Interpolated mesh is not a valid JSON. Please check the generated json file.',
 			),
 		);
 
 		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Issue in src/commands/__fixtures__/env_invalid file - Duplicate key << key1 >> on line 3,Invalid format for key/value << key2=='value3' >> on line 5,Invalid format << key3 >> on line 6,Invalid format for key/value << key4='value4 >> on line 7",
+		    "Interpolated mesh is not a valid JSON. Please check the generated json file.",
 		  ],
 		  [
-		    "Issue in src/commands/__fixtures__/env_invalid file - Duplicate key << key1 >> on line 3,Invalid format for key/value << key2=='value3' >> on line 5,Invalid format << key3 >> on line 6,Invalid format for key/value << key4='value4 >> on line 7",
+		    "Issue in src/commands/__fixtures__/env_invalid file - Interpolated mesh is not a valid JSON. Please check the generated json file.",
+		  ],
+		  [
+		    "Issue in src/commands/__fixtures__/env_invalid file - Interpolated mesh is not a valid JSON. Please check the generated json file.",
 		  ],
 		]
 	`);
@@ -283,7 +286,9 @@ describe('run command tests', () => {
 
 		const runResult = RunCommand.run();
 		await expect(runResult).rejects.toEqual(
-			new Error('The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2'),
+			new Error(
+				'Issue in src/commands/__fixtures__/env_valid file - The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2',
+			),
 		);
 
 		await expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
@@ -292,7 +297,10 @@ describe('run command tests', () => {
 		    "The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2",
 		  ],
 		  [
-		    "The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2",
+		    "Issue in src/commands/__fixtures__/env_valid file - The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2",
+		  ],
+		  [
+		    "Issue in src/commands/__fixtures__/env_valid file - The mesh file cannot be interpolated due to missing keys : newKey1 , newKey2",
 		  ],
 		]
 	`);
@@ -318,7 +326,9 @@ describe('run command tests', () => {
 
 		const runResult = RunCommand.run();
 		await expect(runResult).rejects.toEqual(
-			new Error('Interpolated mesh is not a valid JSON. Please check the generated json file.'),
+			new Error(
+				'Issue in src/commands/__fixtures__/env_valid file - Interpolated mesh is not a valid JSON. Please check the generated json file.',
+			),
 		);
 
 		await expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
@@ -327,7 +337,10 @@ describe('run command tests', () => {
 		    "Interpolated mesh is not a valid JSON. Please check the generated json file.",
 		  ],
 		  [
-		    "Interpolated mesh is not a valid JSON. Please check the generated json file.",
+		    "Issue in src/commands/__fixtures__/env_valid file - Interpolated mesh is not a valid JSON. Please check the generated json file.",
+		  ],
+		  [
+		    "Issue in src/commands/__fixtures__/env_valid file - Interpolated mesh is not a valid JSON. Please check the generated json file.",
 		  ],
 		]
 	`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -297,62 +297,6 @@ function validateFileName(filesList) {
 	}
 }
 
-/**validates the environment file content
- * @param {string} envContent
- * @returns {object} containing the status of validation
- * If validation is failed then the error property including the formatting errors is returned.
- */
-function validateEnvFileFormat(envContent) {
-	//Key should start with a underscore or an alphabet followed by underscore/alphanumeric characters
-	const envKeyRegex = /^[a-zA-Z_]+[a-zA-Z0-9_]*$/;
-
-	const envValueRegex = /^(?:"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'|[^'"\s])+$/;
-
-	/*
-	The above regex matches one or more of below :
-	(?:"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'|[^'"\s])
-	which is
-	1. ?:"(?:\\.|[^\\"])*" : Non capturing group starts and ends with '"'
-	*/
-	const envDict = {};
-	const lines = envContent.split(/\r?\n/);
-	const errors = [];
-
-	for (let index = 0; index < lines.length; index++) {
-		const line = lines[index];
-		const trimmedLine = line.trim();
-		if (trimmedLine.startsWith('#') || trimmedLine === '') {
-			// ignore comment or empty lines
-			continue;
-		}
-
-		if (!trimmedLine.includes('=')) {
-			errors.push(`Invalid format << ${trimmedLine} >> on line ${index + 1}`);
-		} else {
-			const [key, ...values] = trimmedLine.split('=');
-			const value = values.join();
-			if (!envKeyRegex.test(key) || !envValueRegex.test(value)) {
-				// invalid format: key or value does not match regex
-				errors.push(`Invalid format for key/value << ${trimmedLine} >> on line ${index + 1}`);
-			}
-			if (key in envDict) {
-				// duplicate key found
-				errors.push(`Duplicate key << ${key} >> on line ${index + 1}`);
-			}
-			envDict[key] = value;
-		}
-	}
-	if (errors.length) {
-		return {
-			valid: false,
-			error: errors.toString(),
-		};
-	}
-	return {
-		valid: true,
-	};
-}
-
 /**
  * Read the environment file, checks for validation status and interpolate mesh
  * @param {string} inputMeshData
@@ -365,10 +309,10 @@ async function validateAndInterpolateMesh(inputMeshData, envFilePath, command) {
 	const envFileContent = await readFileContents(envFilePath, command, 'env');
 
 	//Validate the environment file
-	const envFileValidity = validateEnvFileFormat(envFileContent);
-	if (envFileValidity.valid) {
+	try {
 		//load env file using dotenv and add 'env' as the root property in the object
-		const envObj = { env: dotenv.config({ path: envFilePath }).parsed };
+		const config = dotenv.parse(envFileContent);
+		const envObj = { env: config };
 		const { interpolationStatus, missingKeys, interpolatedMeshData } = await interpolateMesh(
 			inputMeshData,
 			envObj,
@@ -387,8 +331,8 @@ async function validateAndInterpolateMesh(inputMeshData, envFilePath, command) {
 			command.log(interpolatedMeshData);
 			command.error('Interpolated mesh is not a valid JSON. Please check the generated json file.');
 		}
-	} else {
-		command.error(`Issue in ${envFilePath} file - ` + envFileValidity.error);
+	} catch (err) {
+		command.error(`Issue in ${envFilePath} file - ` + err.message);
 	}
 }
 
@@ -400,7 +344,6 @@ module.exports = {
 	envFileFlag,
 	checkPlaceholders,
 	readFileContents,
-	validateEnvFileFormat,
 	validateAndInterpolateMesh,
 	getAppRootDir,
 	portNoFlag,

--- a/src/utils.js
+++ b/src/utils.js
@@ -311,7 +311,7 @@ function validateEnvFileFormat(envContent) {
 	/*
 	The above regex matches one or more of below :
 	(?:"(?:\\.|[^\\"])*"|'(?:\\.|[^\\'])*'|[^'"\s])
-	which is 
+	which is
 	1. ?:"(?:\\.|[^\\"])*" : Non capturing group starts and ends with '"'
 	*/
 	const envDict = {};
@@ -330,7 +330,7 @@ function validateEnvFileFormat(envContent) {
 			errors.push(`Invalid format << ${trimmedLine} >> on line ${index + 1}`);
 		} else {
 			const [key, ...values] = trimmedLine.split('=');
-            const value = values.join();
+			const value = values.join();
 			if (!envKeyRegex.test(key) || !envValueRegex.test(value)) {
 				// invalid format: key or value does not match regex
 				errors.push(`Invalid format for key/value << ${trimmedLine} >> on line ${index + 1}`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -329,7 +329,8 @@ function validateEnvFileFormat(envContent) {
 		if (!trimmedLine.includes('=')) {
 			errors.push(`Invalid format << ${trimmedLine} >> on line ${index + 1}`);
 		} else {
-			const [key, value] = trimmedLine.split('=', 2);
+			const [key, ...values] = trimmedLine.split('=');
+            const value = values.join();
 			if (!envKeyRegex.test(key) || !envValueRegex.test(value)) {
 				// invalid format: key or value does not match regex
 				errors.push(`Invalid format for key/value << ${trimmedLine} >> on line ${index + 1}`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The current implementation of env validation and interpolation does not work if the values contain `=`

For instance this .env does not work as the URL has `=` in it.

```
COMMERCE_REST_ENDPOINT=https://venia.magento.com/rest/all/schema?services=all
```

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-3346

## Motivation and Context

Bug fix

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
