### PR TITLE
feat:Escape '$' variable from secrets content

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -407,7 +407,7 @@ async function parseSecrets(secretsContent) {
 			cli: false,
 		};
 
-		const [newSecretsContent, placeholderMap] = replaceEscapedVariables(secretsContent);
+		const { secrets: newSecretsContent, placeholderMap } = replaceEscapedVariables(secretsContent);
 		const compiledContent = parseEnv(newSecretsContent, envParserConfig);
 		const compiledSecretsFileContent = replacePlaceholders(compiledContent, placeholderMap);
 		const parsedSecrets = YAML.parse(compiledSecretsFileContent);
@@ -484,7 +484,8 @@ async function encryptSecrets(publicKey, secrets) {
 // Function to replace escaped variables with placeholders
 const replaceEscapedVariables = content => {
 	const placeholderMap = {};
-	const newContent = content.replace(/\\+[$](([a-zA-Z]+)|([{][a-zA-Z]+[}]))/g, matched => {
+	const escapeDollarRegex = /\\+[$](([a-zA-Z]+)|([{][a-zA-Z]+[}]))/g;
+	const newContent = content.replace(escapeDollarRegex, matched => {
 		const slashCount = (matched.match(/\\/g) || []).length;
 		if (slashCount % 2 !== 0) {
 			const placeholder = `__PLACEHOLDER_${Math.random().toString(36).substr(2, 9)}__`;
@@ -495,7 +496,10 @@ const replaceEscapedVariables = content => {
 			return reduceConsecutiveBackslashes(matched);
 		}
 	});
-	return [newContent, placeholderMap];
+	return {
+		secrets: newContent,
+		placeholderMap,
+	};
 };
 
 // Function to replace placeholders back with original variables

--- a/src/utils.js
+++ b/src/utils.js
@@ -406,8 +406,15 @@ async function parseSecrets(secretsContent) {
 			},
 			cli: false,
 		};
-		const compiledSecretsFileContent = parseEnv(secretsContent, envParserConfig);
+		
+		const [newSecretsContent, placeholderMap] = replaceEscapedVariables(secretsContent);
+		const compiledContent = parseEnv(newSecretsContent, envParserConfig);
+		const compiledSecretsFileContent = replacePlaceholders(
+			compiledContent,
+			placeholderMap,
+		);
 		const parsedSecrets = YAML.parse(compiledSecretsFileContent);
+
 		//check if secrets file is empty
 		if (!parsedSecrets) {
 			throw new Error(chalk.red('Invalid YAML file contents. Please verify and try again.'));
@@ -475,6 +482,55 @@ async function encryptSecrets(publicKey, secrets) {
 		logger.error('Unable to encrypt secrets. Please try again. :', error.message);
 		throw new Error(`Unable to encrypt secerts. ${error.message}`);
 	}
+}
+
+// Function to replace escaped variables with placeholders
+const replaceEscapedVariables = content => {
+	const placeholderMap = {};
+	const newContent = content.replace(/\\+[$](([a-zA-Z]+)|([{][a-zA-Z]+[}]))/g, matched => {
+		const slashCount = (matched.match(/\\/g) || []).length;
+		if (slashCount % 2 !== 0) {
+			const placeholder = `__PLACEHOLDER_${Math.random().toString(36).substr(2, 9)}__`;
+			const newValue = reduceConsecutiveBackslashes(matched);
+			placeholderMap[placeholder] = newValue;
+			return placeholder;
+		} else {
+			return reduceConsecutiveBackslashes(matched);
+		}
+	});
+	return [newContent, placeholderMap];
+};
+
+// Function to replace placeholders back with original variables
+const replacePlaceholders = (content, placeholderMap) => {
+	let newContent = content;
+	for (const [key, value] of Object.entries(placeholderMap)) {
+		newContent = newContent.replaceAll(key, value);
+	}
+	return newContent;
+};
+
+// Function to reduce the backslashes
+function reduceConsecutiveBackslashes(str) {
+	let result = '';
+	let i = 0;
+
+	while (i < str.length) {
+		if (str[i] === '\\') {
+			let count = 0;
+			// Count consecutive backslashes
+			while (i < str.length && str[i] === '\\') {
+				count++;
+				i++;
+			}
+			// Append half the count of backslashes (rounded down)
+			result += '\\'.repeat(Math.floor(count / 2));
+		} else {
+			result += str[i];
+			i++;
+		}
+	}
+	return result;
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -406,13 +406,10 @@ async function parseSecrets(secretsContent) {
 			},
 			cli: false,
 		};
-		
+
 		const [newSecretsContent, placeholderMap] = replaceEscapedVariables(secretsContent);
 		const compiledContent = parseEnv(newSecretsContent, envParserConfig);
-		const compiledSecretsFileContent = replacePlaceholders(
-			compiledContent,
-			placeholderMap,
-		);
+		const compiledSecretsFileContent = replacePlaceholders(compiledContent, placeholderMap);
 		const parsedSecrets = YAML.parse(compiledSecretsFileContent);
 
 		//check if secrets file is empty


### PR DESCRIPTION
Escape '$' variable from secrets content

## Description

We have introduced a escape character "\\" for escaping "$" variable from secret content. The code introduces a temporary randomly generated placeholder in place of the "$" variable that is preceded by "\\" symbol and after the parsing of secret content, it replaces back the original string in place of the placeholder. Thus escaping the variable from being parsed.


## Motivation and Context

Earlier we couldn't add "$" with text as string, this used to get parsed and if the value is not found then blank space was replaced for that string. To enable adding of such strings this code is added.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
