### PR TITLE
Unit test for escaping variable in secrets

### DIFF
--- a/src/commands/__fixtures__/sample_mesh_with_escaped_secrets.json
+++ b/src/commands/__fixtures__/sample_mesh_with_escaped_secrets.json
@@ -1,0 +1,21 @@
+{
+	"meshConfig": {
+		"sources": [
+			{
+				"name": "Commerce",
+				"handler": {
+					"graphql": {
+						"endpoint": "https://venia.magento.com/graphql",
+						"operationHeaders": {
+							"secretHome1": "{context.secrets.Home}",
+							"secretHome2": "{context.secrets.HomeString}",
+							"secretHome3": "{context.secrets.HomeWithSlash}",
+							"secretHome4": "{context.secrets.HomeStringWithSlash}"
+						},
+						"useGETForQueries": true
+					}
+				}
+			}
+		]
+	}
+}

--- a/src/commands/__fixtures__/secrets_with_escaped_variables.yaml
+++ b/src/commands/__fixtures__/secrets_with_escaped_variables.yaml
@@ -1,0 +1,4 @@
+Home: $HOME
+HomeString: \$HOME
+HomeWithSlash: \\$HOME
+HomeStringWithSlash: \\\$HOME

--- a/src/commands/api-mesh/__tests__/run.test.js
+++ b/src/commands/api-mesh/__tests__/run.test.js
@@ -58,7 +58,7 @@ jest.mock('@adobe-apimesh/mesh-builder', () => {
 });
 
 jest.mock('envsub/js/envsub-parser', () => {
-	return (contents) => {
+	return contents => {
 		return contents.replaceAll('$HOME', 'rootPath');
 	};
 });

--- a/src/commands/api-mesh/__tests__/run.test.js
+++ b/src/commands/api-mesh/__tests__/run.test.js
@@ -984,7 +984,7 @@ describe('run command tests', () => {
 
 	test('should escape variables that are preceded by "\" ', async () => {
 		parseSpy.mockResolvedValueOnce({
-			args: { file: 'src/commands/__fixtures__/sample_secrets_mesh.json' },
+			args: { file: 'src/commands/__fixtures__/sample_mesh_with_escaped_secrets.json' },
 			flags: {
 				secrets: 'src/commands/__fixtures__/secrets_with_escaped_variables.yaml',
 				debug: false,

--- a/src/commands/api-mesh/__tests__/run.test.js
+++ b/src/commands/api-mesh/__tests__/run.test.js
@@ -57,6 +57,12 @@ jest.mock('@adobe-apimesh/mesh-builder', () => {
 	};
 });
 
+jest.mock('envsub/js/envsub-parser', () => {
+	return (contents, args) => {
+		return contents.replaceAll('$HOME', 'rootPath');
+	};
+});
+
 let logSpy = null;
 let errorLogSpy = null;
 let parseSpy = null;
@@ -973,6 +979,23 @@ describe('run command tests', () => {
 
 		await RunCommand.run();
 		expect(writeSecretsFile).toHaveBeenCalled();
+		expect(startGraphqlServer).toHaveBeenCalledWith(expect.anything(), defaultPort, false);
+	});
+
+	test('should escape variables that are preceded by "\" ', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: { file: 'src/commands/__fixtures__/sample_secrets_mesh.json' },
+			flags: {
+				secrets: 'src/commands/__fixtures__/secrets_with_escaped_variables.yaml',
+				debug: false,
+			},
+		});
+
+		await RunCommand.run();
+		expect(writeSecretsFile).toHaveBeenCalledWith(
+			'Home: rootPath\nHomeString: $HOME\nHomeWithSlash: \\rootPath\nHomeStringWithSlash: \\$HOME\n',
+			expect.anything(),
+		);
 		expect(startGraphqlServer).toHaveBeenCalledWith(expect.anything(), defaultPort, false);
 	});
 });

--- a/src/commands/api-mesh/__tests__/run.test.js
+++ b/src/commands/api-mesh/__tests__/run.test.js
@@ -58,7 +58,7 @@ jest.mock('@adobe-apimesh/mesh-builder', () => {
 });
 
 jest.mock('envsub/js/envsub-parser', () => {
-	return (contents, args) => {
+	return (contents) => {
 		return contents.replaceAll('$HOME', 'rootPath');
 	};
 });
@@ -982,7 +982,7 @@ describe('run command tests', () => {
 		expect(startGraphqlServer).toHaveBeenCalledWith(expect.anything(), defaultPort, false);
 	});
 
-	test('should escape variables that are preceded by "\" ', async () => {
+	test('should escape variables that are preceded by backslash symbol', async () => {
 		parseSpy.mockResolvedValueOnce({
 			args: { file: 'src/commands/__fixtures__/sample_mesh_with_escaped_secrets.json' },
 			flags: {


### PR DESCRIPTION
Unit test for escaping variable in secrets

## Description
Added Unit test
The variables which is not preceded with \ shouldn't be escaped
eg: $HOME -> homePath (value of $HOME)

The variables preceded with \ should be escaped
eg: \$HOME -> $HOME

If a variable is preceded by 2 backslashes then the backslash is escaped and the variable is parsed
eg: \\$HOME -> \homepath

If a variable is preceded by 3 backslashes, then 2nd backslash is escaped and the variable is also escaped
eg: \\\$HOME -> \$HOME


