### PR TITLE
Secrets validation fix on proxy handler.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.6.1-beta.1",
+	"version": "3.6.1-beta.2",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/server.js
+++ b/src/server.js
@@ -55,6 +55,13 @@ const getCORSOptions = () => {
 // Custom get secrets handler
 const getSecretsHandler = {
 	get: function (target, prop, receiver) {
+		if (prop === 'toJSON') {
+			// Handle the toJSON case
+			return () => target;
+	   	} 
+		if (Object.keys(target).length === 0) {
+			return undefined;
+		}
 		if (prop in target) {
 			return Reflect.get(target, prop, receiver);
 		} else {

--- a/src/server.js
+++ b/src/server.js
@@ -59,9 +59,6 @@ const getSecretsHandler = {
 			// Handle the toJSON case
 			return () => target;
 		}
-		if (Object.keys(target).length === 0) {
-			return undefined;
-		}
 		if (prop in target) {
 			return Reflect.get(target, prop, receiver);
 		} else {

--- a/src/server.js
+++ b/src/server.js
@@ -58,7 +58,7 @@ const getSecretsHandler = {
 		if (prop === 'toJSON') {
 			// Handle the toJSON case
 			return () => target;
-	   	} 
+		}
 		if (Object.keys(target).length === 0) {
 			return undefined;
 		}


### PR DESCRIPTION
Secrets validation quick fix on proxy handler.

## Description

When mesh uses remote hooks, secrets validation were failing as **toJSON** was not allowed explicitly. 
Error message that it was throwing: `The secret toJSON is not available.`

This PR fix this error.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
As this is related to local development, so verified against local development environment by using a mesh with remote hooks.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
