### PR TITLE
Cext 3315 enable edge cli

### DIFF
--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -78,7 +78,7 @@ jest.mock('chalk', () => ({
 	underline: {
 		blue: jest.fn(text => text),
 	},
-	yellow: jest.fn(text => text),
+	bgYellow: jest.fn(text => text),
 }));
 jest.mock('crypto');
 

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -75,6 +75,10 @@ jest.mock('../../../lib/devConsole');
 jest.mock('chalk', () => ({
 	red: jest.fn(text => text), // Return the input text without any color formatting
 	bold: jest.fn(text => text),
+	underline: {
+		blue: jest.fn(text => text),
+	},
+	yellow: jest.fn(text => text),
 }));
 jest.mock('crypto');
 
@@ -409,9 +413,22 @@ describe('create command tests', () => {
 		    "dummy_api_key",
 		  ],
 		  [
-		    "Mesh Endpoint: %s
+		    "
+		API Mesh now runs at the edge and legacy mesh URLs will be deprecated.
+		Use the following link to find more information on how to migrate your mesh:",
+		  ],
+		  [
+		    "https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration
 		",
+		  ],
+		  [
+		    "Legacy Mesh Endpoint: %s",
 		    "https://graph.adobe.io/api/dummy_mesh_id/graphql?api_key=dummy_api_key",
+		  ],
+		  [
+		    "Edge Mesh Endpoint: %s
+		",
+		    "https://edge-sandbox-graph.adobe.io/api/dummy_mesh_id/graphql",
 		  ],
 		]
 	`);
@@ -502,9 +519,22 @@ describe('create command tests', () => {
 		    "dummy_api_key",
 		  ],
 		  [
-		    "Mesh Endpoint: %s
+		    "
+		API Mesh now runs at the edge and legacy mesh URLs will be deprecated.
+		Use the following link to find more information on how to migrate your mesh:",
+		  ],
+		  [
+		    "https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration
 		",
+		  ],
+		  [
+		    "Legacy Mesh Endpoint: %s",
 		    "https://tigraph.adobe.io/dummy_mesh_id/graphql",
+		  ],
+		  [
+		    "Edge Mesh Endpoint: %s
+		",
+		    "https://edge-sandbox-graph.adobe.io/api/dummy_mesh_id/graphql",
 		  ],
 		]
 	`);
@@ -693,9 +723,22 @@ describe('create command tests', () => {
 		    "dummy_api_key",
 		  ],
 		  [
-		    "Mesh Endpoint: %s
+		    "
+		API Mesh now runs at the edge and legacy mesh URLs will be deprecated.
+		Use the following link to find more information on how to migrate your mesh:",
+		  ],
+		  [
+		    "https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration
 		",
+		  ],
+		  [
+		    "Legacy Mesh Endpoint: %s",
 		    "https://graph.adobe.io/api/dummy_mesh_id/graphql?api_key=dummy_api_key",
+		  ],
+		  [
+		    "Edge Mesh Endpoint: %s
+		",
+		    "https://edge-sandbox-graph.adobe.io/api/dummy_mesh_id/graphql",
 		  ],
 		]
 	`);
@@ -1880,26 +1923,6 @@ describe('create command tests', () => {
 		expect(logSpy).toHaveBeenCalledWith(
 			expect.stringContaining('Edge Mesh Endpoint:'),
 			'https://edge-sandbox-graph.adobe.io/api/dummy_mesh_id/graphql',
-		);
-	});
-
-	test('should not show edge mesh url if feature is disabled', async () => {
-		// mock the edge mesh url feature to be disabled
-		getTenantFeatures.mockResolvedValueOnce({
-			imsOrgId: selectedOrg.code,
-			showCloudflareURL: false,
-		});
-
-		await CreateCommand.run();
-
-		expect(logSpy).not.toHaveBeenCalledWith(
-			expect.stringContaining('Edge Mesh Endpoint:'),
-			expect.any(String),
-		);
-
-		expect(logSpy).toHaveBeenCalledWith(
-			expect.stringContaining('Mesh Endpoint:'),
-			'https://graph.adobe.io/api/dummy_mesh_id/graphql?api_key=dummy_api_key',
 		);
 	});
 

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -395,5 +395,4 @@ describe('describe command tests', () => {
 			'https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql',
 		);
 	});
-
 });

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -24,6 +24,13 @@ jest.mock('@adobe/aio-cli-lib-console', () => ({
 	cleanStdOut: jest.fn(),
 }));
 jest.mock('../../../lib/devConsole');
+jest.mock('chalk', () => ({
+	bold: jest.fn(text => text), // Return the input text without any color formatting
+	underline: {
+		blue: jest.fn(text => text),
+	},
+	bgYellow: jest.fn(text => text),
+}));
 
 const DescribeCommand = require('../describe');
 const { initSdk, initRequestId } = require('../../../helpers');
@@ -179,26 +186,26 @@ describe('describe command tests', () => {
 		    "dummy_meshId",
 		  ],
 		  [
-		    "[43m[49m
-		[43mAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.[49m
-		[43mUse the following link to find more information on how to migrate your mesh:[49m",
+		    "
+		API Mesh now runs at the edge and legacy mesh URLs will be deprecated.
+		Use the following link to find more information on how to migrate your mesh:",
 		  ],
 		  [
-		    "[4m[34mhttps://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration[39m[24m
-		[4m[34m[39m[24m",
+		    "https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration
+		",
 		  ],
 		  [
 		    "Legacy Mesh Endpoint: %s",
 		    "https://graph.adobe.io/api/dummy_meshId/graphql",
 		  ],
 		  [
-		    "[1mEdge Mesh Endpoint: %s[22m
-		[1m[22m",
+		    "Edge Mesh Endpoint: %s
+		",
 		    "https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql",
 		  ],
 		  [
-		    "[43mMake sure that you update your mesh before using the edge mesh endpoint.[49m
-		[43mYou can validate your edge mesh status using the status command.[49m",
+		    "Make sure that you update your mesh before using the edge mesh endpoint.
+		You can validate your edge mesh status using the status command.",
 		  ],
 		]
 	`);
@@ -244,26 +251,26 @@ describe('describe command tests', () => {
 		    "dummy_meshId",
 		  ],
 		  [
-		    "[43m[49m
-		[43mAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.[49m
-		[43mUse the following link to find more information on how to migrate your mesh:[49m",
+		    "
+		API Mesh now runs at the edge and legacy mesh URLs will be deprecated.
+		Use the following link to find more information on how to migrate your mesh:",
 		  ],
 		  [
-		    "[4m[34mhttps://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration[39m[24m
-		[4m[34m[39m[24m",
+		    "https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration
+		",
 		  ],
 		  [
 		    "Legacy Mesh Endpoint: %s",
 		    "https://graph.adobe.io/api/dummy_meshId/graphql?api_key=dummy_apiKey",
 		  ],
 		  [
-		    "[1mEdge Mesh Endpoint: %s[22m
-		[1m[22m",
+		    "Edge Mesh Endpoint: %s
+		",
 		    "https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql",
 		  ],
 		  [
-		    "[43mMake sure that you update your mesh before using the edge mesh endpoint.[49m
-		[43mYou can validate your edge mesh status using the status command.[49m",
+		    "Make sure that you update your mesh before using the edge mesh endpoint.
+		You can validate your edge mesh status using the status command.",
 		  ],
 		]
 	`);
@@ -313,26 +320,26 @@ describe('describe command tests', () => {
 		    "dummy_meshId",
 		  ],
 		  [
-		    "[43m[49m
-		[43mAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.[49m
-		[43mUse the following link to find more information on how to migrate your mesh:[49m",
+		    "
+		API Mesh now runs at the edge and legacy mesh URLs will be deprecated.
+		Use the following link to find more information on how to migrate your mesh:",
 		  ],
 		  [
-		    "[4m[34mhttps://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration[39m[24m
-		[4m[34m[39m[24m",
+		    "https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration
+		",
 		  ],
 		  [
 		    "Legacy Mesh Endpoint: %s",
 		    "https://tigraph.adobe.io/dummy_meshId/graphql",
 		  ],
 		  [
-		    "[1mEdge Mesh Endpoint: %s[22m
-		[1m[22m",
+		    "Edge Mesh Endpoint: %s
+		",
 		    "https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql",
 		  ],
 		  [
-		    "[43mMake sure that you update your mesh before using the edge mesh endpoint.[49m
-		[43mYou can validate your edge mesh status using the status command.[49m",
+		    "Make sure that you update your mesh before using the edge mesh endpoint.
+		You can validate your edge mesh status using the status command.",
 		  ],
 		]
 	`);
@@ -388,4 +395,5 @@ describe('describe command tests', () => {
 			'https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql',
 		);
 	});
+
 });

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -204,8 +204,8 @@ describe('describe command tests', () => {
 		    "https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql",
 		  ],
 		  [
-		    "Make sure that you update your mesh before using the edge mesh endpoint.
-		You can validate your edge mesh status using the status command.",
+		    "Update your mesh before using the edge mesh endpoint.
+		You can validate your edge mesh status using the aio api-mesh status command.",
 		  ],
 		]
 	`);
@@ -269,8 +269,8 @@ describe('describe command tests', () => {
 		    "https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql",
 		  ],
 		  [
-		    "Make sure that you update your mesh before using the edge mesh endpoint.
-		You can validate your edge mesh status using the status command.",
+		    "Update your mesh before using the edge mesh endpoint.
+		You can validate your edge mesh status using the aio api-mesh status command.",
 		  ],
 		]
 	`);
@@ -338,8 +338,8 @@ describe('describe command tests', () => {
 		    "https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql",
 		  ],
 		  [
-		    "Make sure that you update your mesh before using the edge mesh endpoint.
-		You can validate your edge mesh status using the status command.",
+		    "Update your mesh before using the edge mesh endpoint.
+		You can validate your edge mesh status using the aio api-mesh status command.",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/describe.test.js
+++ b/src/commands/api-mesh/__tests__/describe.test.js
@@ -179,9 +179,26 @@ describe('describe command tests', () => {
 		    "dummy_meshId",
 		  ],
 		  [
-		    "Mesh Endpoint: %s
-		",
+		    "[43m[49m
+		[43mAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.[49m
+		[43mUse the following link to find more information on how to migrate your mesh:[49m",
+		  ],
+		  [
+		    "[4m[34mhttps://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration[39m[24m
+		[4m[34m[39m[24m",
+		  ],
+		  [
+		    "Legacy Mesh Endpoint: %s",
 		    "https://graph.adobe.io/api/dummy_meshId/graphql",
+		  ],
+		  [
+		    "[1mEdge Mesh Endpoint: %s[22m
+		[1m[22m",
+		    "https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql",
+		  ],
+		  [
+		    "[43mMake sure that you update your mesh before using the edge mesh endpoint.[49m
+		[43mYou can validate your edge mesh status using the status command.[49m",
 		  ],
 		]
 	`);
@@ -227,9 +244,26 @@ describe('describe command tests', () => {
 		    "dummy_meshId",
 		  ],
 		  [
-		    "Mesh Endpoint: %s
-		",
+		    "[43m[49m
+		[43mAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.[49m
+		[43mUse the following link to find more information on how to migrate your mesh:[49m",
+		  ],
+		  [
+		    "[4m[34mhttps://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration[39m[24m
+		[4m[34m[39m[24m",
+		  ],
+		  [
+		    "Legacy Mesh Endpoint: %s",
 		    "https://graph.adobe.io/api/dummy_meshId/graphql?api_key=dummy_apiKey",
+		  ],
+		  [
+		    "[1mEdge Mesh Endpoint: %s[22m
+		[1m[22m",
+		    "https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql",
+		  ],
+		  [
+		    "[43mMake sure that you update your mesh before using the edge mesh endpoint.[49m
+		[43mYou can validate your edge mesh status using the status command.[49m",
 		  ],
 		]
 	`);
@@ -279,9 +313,26 @@ describe('describe command tests', () => {
 		    "dummy_meshId",
 		  ],
 		  [
-		    "Mesh Endpoint: %s
-		",
+		    "[43m[49m
+		[43mAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.[49m
+		[43mUse the following link to find more information on how to migrate your mesh:[49m",
+		  ],
+		  [
+		    "[4m[34mhttps://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration[39m[24m
+		[4m[34m[39m[24m",
+		  ],
+		  [
+		    "Legacy Mesh Endpoint: %s",
 		    "https://tigraph.adobe.io/dummy_meshId/graphql",
+		  ],
+		  [
+		    "[1mEdge Mesh Endpoint: %s[22m
+		[1m[22m",
+		    "https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql",
+		  ],
+		  [
+		    "[43mMake sure that you update your mesh before using the edge mesh endpoint.[49m
+		[43mYou can validate your edge mesh status using the status command.[49m",
 		  ],
 		]
 	`);
@@ -335,26 +386,6 @@ describe('describe command tests', () => {
 		expect(logSpy).toHaveBeenCalledWith(
 			expect.stringContaining('Edge Mesh Endpoint:'),
 			'https://edge-sandbox-graph.adobe.io/api/dummy_meshId/graphql',
-		);
-	});
-
-	test('should not show edge mesh url if feature is disabled', async () => {
-		// mock the edge mesh url feature to be disabled
-		getTenantFeatures.mockResolvedValueOnce({
-			imsOrgId: selectedOrg.code,
-			showCloudflareURL: false,
-		});
-
-		await DescribeCommand.run();
-
-		expect(logSpy).not.toHaveBeenCalledWith(
-			expect.stringContaining('Edge Mesh Endpoint:'),
-			expect.any(String),
-		);
-
-		expect(logSpy).toHaveBeenCalledWith(
-			expect.stringContaining('Mesh Endpoint:'),
-			'https://graph.adobe.io/api/dummy_meshId/graphql?api_key=dummy_apiKey',
 		);
 	});
 });

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -173,7 +173,6 @@ class CreateCommand extends Command {
 							const edgeMeshUrl = buildEdgeMeshUrl(mesh.meshId, workspaceName);
 							this.log('Legacy Mesh Endpoint: %s', meshUrl);
 							this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
-							
 						} else {
 							this.log('Unable to subscribe API Key %s to API Mesh service', apiKey);
 						}

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/core');
 const chalk = require('chalk');
-const { initSdk, initRequestId, promptConfirm, importFiles, createNotice } = require('../../helpers');
+const { initSdk, initRequestId, promptConfirm, importFiles } = require('../../helpers');
 const logger = require('../../classes/logger');
 const {
 	ignoreCacheFlag,
@@ -171,14 +171,6 @@ class CreateCommand extends Command {
 							);
 
 							const edgeMeshUrl = buildEdgeMeshUrl(mesh.meshId, workspaceName);
-							// this.log(
-							// 	await createNotice(
-							// 		`API Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:\n${chalk.underline.blue(
-							// 			'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration',
-							// 		)}`,
-							// 	),
-							// );
-
 							this.log(
 								chalk.yellow(
 									`\nAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:`,
@@ -189,7 +181,6 @@ class CreateCommand extends Command {
 									'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration\n',
 								),
 							);
-
 							this.log('Legacy Mesh Endpoint: %s', meshUrl);
 							this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
 						} else {

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -27,7 +27,7 @@ const {
 	validateSecretsFile,
 	encryptSecrets,
 } = require('../../utils');
-const { createMesh, getTenantFeatures, getPublicEncryptionKey } = require('../../lib/devConsole');
+const { createMesh, getPublicEncryptionKey } = require('../../lib/devConsole');
 const { buildEdgeMeshUrl, buildMeshUrl } = require('../../urlBuilder');
 
 class CreateCommand extends Command {
@@ -170,15 +170,10 @@ class CreateCommand extends Command {
 								apiKey,
 							);
 
-							const { showCloudflareURL: showEdgeMeshUrl } = await getTenantFeatures(imsOrgCode);
-
-							if (showEdgeMeshUrl) {
-								const edgeMeshUrl = buildEdgeMeshUrl(mesh.meshId, workspaceName);
-								this.log('Legacy Mesh Endpoint: %s', meshUrl);
-								this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
-							} else {
-								this.log('Mesh Endpoint: %s\n', meshUrl);
-							}
+							const edgeMeshUrl = buildEdgeMeshUrl(mesh.meshId, workspaceName);
+							this.log('Legacy Mesh Endpoint: %s', meshUrl);
+							this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
+							
 						} else {
 							this.log('Unable to subscribe API Key %s to API Mesh service', apiKey);
 						}

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -172,7 +172,7 @@ class CreateCommand extends Command {
 
 							const edgeMeshUrl = buildEdgeMeshUrl(mesh.meshId, workspaceName);
 							this.log(
-								chalk.yellow(
+								chalk.bgYellow(
 									`\nAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:`,
 								),
 							);

--- a/src/commands/api-mesh/create.js
+++ b/src/commands/api-mesh/create.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 
 const { Command } = require('@oclif/core');
 const chalk = require('chalk');
-const { initSdk, initRequestId, promptConfirm, importFiles } = require('../../helpers');
+const { initSdk, initRequestId, promptConfirm, importFiles, createNotice } = require('../../helpers');
 const logger = require('../../classes/logger');
 const {
 	ignoreCacheFlag,
@@ -171,6 +171,25 @@ class CreateCommand extends Command {
 							);
 
 							const edgeMeshUrl = buildEdgeMeshUrl(mesh.meshId, workspaceName);
+							// this.log(
+							// 	await createNotice(
+							// 		`API Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:\n${chalk.underline.blue(
+							// 			'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration',
+							// 		)}`,
+							// 	),
+							// );
+
+							this.log(
+								chalk.yellow(
+									`\nAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:`,
+								),
+							);
+							this.log(
+								chalk.underline.blue(
+									'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration\n',
+								),
+							);
+
 							this.log('Legacy Mesh Endpoint: %s', meshUrl);
 							this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
 						} else {

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -32,7 +32,7 @@ class DescribeCommand extends Command {
 
 		const { flags } = await this.parse(DescribeCommand);
 		const ignoreCache = await flags.ignoreCache;
-		const { imsOrgId, imsOrgCode, projectId, workspaceId, workspaceName } = await initSdk({
+		const { imsOrgId, projectId, workspaceId, workspaceName } = await initSdk({
 			ignoreCache,
 		});
 

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -13,7 +13,7 @@ const { Command } = require('@oclif/command');
 const chalk = require('chalk');
 
 const logger = require('../../classes/logger');
-const { initSdk, initRequestId } = require('../../helpers');
+const { initSdk, initRequestId, createNotice } = require('../../helpers');
 const { ignoreCacheFlag } = require('../../utils');
 const { describeMesh } = require('../../lib/devConsole');
 const { buildMeshUrl, buildEdgeMeshUrl } = require('../../urlBuilder');
@@ -59,8 +59,22 @@ class DescribeCommand extends Command {
 					this.log('Mesh ID: %s', meshId);
 
 					const edgeMeshUrl = buildEdgeMeshUrl(meshId, workspaceName);
+					this.log(
+						await createNotice(
+							`API Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:\n${chalk.underline.blue(
+								'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration',
+							)}`,
+						),
+					);
 					this.log('Legacy Mesh Endpoint: %s', meshUrl);
 					this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
+
+					// this.log(chalk.bgYellow('Make sure that you update your mesh before using the edge mesh endpoint. You can validate your edge mesh status using the status command.'));
+					this.log(
+						await createNotice(
+							`Make sure that you update your mesh before using the edge mesh endpoint.\nYou can validate your edge mesh status using the status command.`,
+						),
+					);
 
 					return meshDetails;
 				} else {

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -13,7 +13,7 @@ const { Command } = require('@oclif/command');
 const chalk = require('chalk');
 
 const logger = require('../../classes/logger');
-const { initSdk, initRequestId, createNotice } = require('../../helpers');
+const { initSdk, initRequestId } = require('../../helpers');
 const { ignoreCacheFlag } = require('../../utils');
 const { describeMesh } = require('../../lib/devConsole');
 const { buildMeshUrl, buildEdgeMeshUrl } = require('../../urlBuilder');
@@ -59,14 +59,6 @@ class DescribeCommand extends Command {
 					this.log('Mesh ID: %s', meshId);
 
 					const edgeMeshUrl = buildEdgeMeshUrl(meshId, workspaceName);
-					// this.log(
-					// 	await createNotice(
-					// 		`API Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:\n${chalk.underline.blue(
-					// 			'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration',
-					// 		)}`,
-					// 	),
-					// );
-
 					this.log(
 						chalk.bgYellow(
 							`\nAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:`,
@@ -77,22 +69,13 @@ class DescribeCommand extends Command {
 							'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration\n',
 						),
 					);
-
 					this.log('Legacy Mesh Endpoint: %s', meshUrl);
 					this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
-
 					this.log(
 						chalk.bgYellow(
 							'Make sure that you update your mesh before using the edge mesh endpoint.\nYou can validate your edge mesh status using the status command.',
 						),
 					);
-
-					// this.log(
-					// 	await createNotice(
-					// 		`Make sure that you update your mesh before using the edge mesh endpoint.\nYou can validate your edge mesh status using the status command.`,
-					// 	),
-					// );
-
 					return meshDetails;
 				} else {
 					logger.error(

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -15,7 +15,7 @@ const chalk = require('chalk');
 const logger = require('../../classes/logger');
 const { initSdk, initRequestId } = require('../../helpers');
 const { ignoreCacheFlag } = require('../../utils');
-const { describeMesh, getTenantFeatures } = require('../../lib/devConsole');
+const { describeMesh } = require('../../lib/devConsole');
 const { buildMeshUrl, buildEdgeMeshUrl } = require('../../urlBuilder');
 
 require('dotenv').config();
@@ -41,7 +41,6 @@ class DescribeCommand extends Command {
 
 			if (meshDetails) {
 				const { meshId, apiKey } = meshDetails;
-				const { showCloudflareURL: showEdgeMeshUrl } = await getTenantFeatures(imsOrgCode);
 
 				if (meshId) {
 					const meshUrl = await buildMeshUrl(
@@ -59,13 +58,9 @@ class DescribeCommand extends Command {
 					this.log('Workspace ID: %s', workspaceId);
 					this.log('Mesh ID: %s', meshId);
 
-					if (showEdgeMeshUrl) {
-						const edgeMeshUrl = buildEdgeMeshUrl(meshId, workspaceName);
-						this.log('Legacy Mesh Endpoint: %s', meshUrl);
-						this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
-					} else {
-						this.log('Mesh Endpoint: %s\n', meshUrl);
-					}
+					const edgeMeshUrl = buildEdgeMeshUrl(meshId, workspaceName);
+					this.log('Legacy Mesh Endpoint: %s', meshUrl);
+					this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
 
 					return meshDetails;
 				} else {

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -59,22 +59,39 @@ class DescribeCommand extends Command {
 					this.log('Mesh ID: %s', meshId);
 
 					const edgeMeshUrl = buildEdgeMeshUrl(meshId, workspaceName);
+					// this.log(
+					// 	await createNotice(
+					// 		`API Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:\n${chalk.underline.blue(
+					// 			'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration',
+					// 		)}`,
+					// 	),
+					// );
+
 					this.log(
-						await createNotice(
-							`API Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:\n${chalk.underline.blue(
-								'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration',
-							)}`,
+						chalk.bgYellow(
+							`\nAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:`,
 						),
 					);
+					this.log(
+						chalk.underline.blue(
+							'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration\n',
+						),
+					);
+
 					this.log('Legacy Mesh Endpoint: %s', meshUrl);
 					this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
 
-					// this.log(chalk.bgYellow('Make sure that you update your mesh before using the edge mesh endpoint. You can validate your edge mesh status using the status command.'));
 					this.log(
-						await createNotice(
-							`Make sure that you update your mesh before using the edge mesh endpoint.\nYou can validate your edge mesh status using the status command.`,
+						chalk.bgYellow(
+							'Make sure that you update your mesh before using the edge mesh endpoint.\nYou can validate your edge mesh status using the status command.',
 						),
 					);
+
+					// this.log(
+					// 	await createNotice(
+					// 		`Make sure that you update your mesh before using the edge mesh endpoint.\nYou can validate your edge mesh status using the status command.`,
+					// 	),
+					// );
 
 					return meshDetails;
 				} else {

--- a/src/commands/api-mesh/describe.js
+++ b/src/commands/api-mesh/describe.js
@@ -73,7 +73,7 @@ class DescribeCommand extends Command {
 					this.log(chalk.bold('Edge Mesh Endpoint: %s\n'), edgeMeshUrl);
 					this.log(
 						chalk.bgYellow(
-							'Make sure that you update your mesh before using the edge mesh endpoint.\nYou can validate your edge mesh status using the status command.',
+							'Update your mesh before using the edge mesh endpoint.\nYou can validate your edge mesh status using the aio api-mesh status command.',
 						),
 					);
 					return meshDetails;

--- a/src/commands/api-mesh/status.js
+++ b/src/commands/api-mesh/status.js
@@ -2,7 +2,7 @@ const { Command } = require('@oclif/core');
 const chalk = require('chalk');
 
 const logger = require('../../classes/logger');
-const { initRequestId, initSdk } = require('../../helpers');
+const { initRequestId, initSdk, createNotice } = require('../../helpers');
 const { getMeshId, getMesh, getMeshDeployments } = require('../../lib/devConsole');
 const { ignoreCacheFlag } = require('../../utils');
 
@@ -37,6 +37,25 @@ class StatusCommand extends Command {
 		if (meshId) {
 			try {
 				const mesh = await getMesh(imsOrgId, projectId, workspaceId, workspaceName, meshId);
+				
+				// this.log(
+				// 	await createNotice(
+				// 		`API Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:\n${chalk.underline.blue(
+				// 			'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration',
+				// 		)}`,
+				// 	),
+				// );
+
+				this.log(
+					chalk.bgYellow(
+						`\nAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:`,
+					),
+				);
+				this.log(
+					chalk.underline.blue(
+						'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration\n',
+					),
+				);
 				const meshLabel = chalk.bold(`Legacy Mesh:`);
 
 				this.log(''.padEnd(102, '*'));

--- a/src/commands/api-mesh/status.js
+++ b/src/commands/api-mesh/status.js
@@ -6,7 +6,6 @@ const { initRequestId, initSdk } = require('../../helpers');
 const {
 	getMeshId,
 	getMesh,
-	getTenantFeatures,
 	getMeshDeployments,
 } = require('../../lib/devConsole');
 const { ignoreCacheFlag } = require('../../utils');
@@ -41,15 +40,12 @@ class StatusCommand extends Command {
 
 		if (meshId) {
 			try {
-				const { showCloudflareURL: showEdgeMeshUrl } = await getTenantFeatures(imsOrgCode);
 				const mesh = await getMesh(imsOrgId, projectId, workspaceId, workspaceName, meshId);
-				const meshLabel = showEdgeMeshUrl ? chalk.bold(`Legacy Mesh:`) : 'Your mesh';
+				const meshLabel = chalk.bold(`Legacy Mesh:`);
 
 				this.log(''.padEnd(102, '*'));
 				this.displayMeshStatus(mesh, meshLabel);
-				if (showEdgeMeshUrl) {
-					await this.displayEdgeMeshStatus(mesh, imsOrgCode, projectId, workspaceId);
-				}
+				await this.displayEdgeMeshStatus(mesh, imsOrgCode, projectId, workspaceId);
 				this.log(''.padEnd(102, '*'));
 			} catch (err) {
 				this.log(err.message);

--- a/src/commands/api-mesh/status.js
+++ b/src/commands/api-mesh/status.js
@@ -3,11 +3,7 @@ const chalk = require('chalk');
 
 const logger = require('../../classes/logger');
 const { initRequestId, initSdk } = require('../../helpers');
-const {
-	getMeshId,
-	getMesh,
-	getMeshDeployments,
-} = require('../../lib/devConsole');
+const { getMeshId, getMesh, getMeshDeployments } = require('../../lib/devConsole');
 const { ignoreCacheFlag } = require('../../utils');
 
 require('dotenv').config();

--- a/src/commands/api-mesh/status.js
+++ b/src/commands/api-mesh/status.js
@@ -2,7 +2,7 @@ const { Command } = require('@oclif/core');
 const chalk = require('chalk');
 
 const logger = require('../../classes/logger');
-const { initRequestId, initSdk, createNotice } = require('../../helpers');
+const { initRequestId, initSdk } = require('../../helpers');
 const { getMeshId, getMesh, getMeshDeployments } = require('../../lib/devConsole');
 const { ignoreCacheFlag } = require('../../utils');
 
@@ -37,15 +37,6 @@ class StatusCommand extends Command {
 		if (meshId) {
 			try {
 				const mesh = await getMesh(imsOrgId, projectId, workspaceId, workspaceName, meshId);
-				
-				// this.log(
-				// 	await createNotice(
-				// 		`API Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:\n${chalk.underline.blue(
-				// 			'https://developer.adobe.com/graphql-mesh-gateway/mesh/release/migration',
-				// 		)}`,
-				// 	),
-				// );
-
 				this.log(
 					chalk.bgYellow(
 						`\nAPI Mesh now runs at the edge and legacy mesh URLs will be deprecated.\nUse the following link to find more information on how to migrate your mesh:`,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,6 +17,7 @@ const { getToken, context } = require('@adobe/aio-lib-ims');
 const { CLI } = require('@adobe/aio-lib-ims/src/context');
 const libConsoleCLI = require('@adobe/aio-cli-lib-console');
 const { getCliEnv } = require('@adobe/aio-lib-env');
+const chalk = require('chalk');
 
 const logger = require('../src/classes/logger');
 const { UUID } = require('./classes/UUID');
@@ -880,6 +881,21 @@ async function writeSecretsFile(secretsData, meshId) {
 	}
 }
 
+// Function to generate the notice message with multiline support
+async function createNotice(message) {
+	const lines = message.split('\n');
+	const maxLength = Math.max(...lines.map(line => line.length));
+	const border = chalk.yellow('='.repeat(maxLength + 12));
+
+	const formattedLines = lines.map(line => {
+		const padding = ' '.repeat(maxLength - line.length);
+		return `${chalk.whiteBright(line)}${padding}`;
+	});
+
+	const noticeMessage = formattedLines.join('\n');
+	return `${border}\n${chalk.blueBright.bold('ⓘ')} ${noticeMessage} \n${border}`;
+}
+
 module.exports = {
 	objToString,
 	promptInput,
@@ -897,4 +913,5 @@ module.exports = {
 	startGraphqlServer,
 	setUpTenantFiles,
 	writeSecretsFile,
+	createNotice,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,7 +17,6 @@ const { getToken, context } = require('@adobe/aio-lib-ims');
 const { CLI } = require('@adobe/aio-lib-ims/src/context');
 const libConsoleCLI = require('@adobe/aio-cli-lib-console');
 const { getCliEnv } = require('@adobe/aio-lib-env');
-const chalk = require('chalk');
 
 const logger = require('../src/classes/logger');
 const { UUID } = require('./classes/UUID');
@@ -881,21 +880,6 @@ async function writeSecretsFile(secretsData, meshId) {
 	}
 }
 
-// Function to generate the notice message with multiline support
-async function createNotice(message) {
-	const lines = message.split('\n');
-	const maxLength = Math.max(...lines.map(line => line.length));
-	const border = chalk.yellow('='.repeat(maxLength + 12));
-
-	const formattedLines = lines.map(line => {
-		const padding = ' '.repeat(maxLength - line.length);
-		return `${chalk.whiteBright(line)}${padding}`;
-	});
-
-	const noticeMessage = formattedLines.join('\n');
-	return `${border}\n${chalk.blueBright.bold('ⓘ')} ${noticeMessage} \n${border}`;
-}
-
 module.exports = {
 	objToString,
 	promptInput,
@@ -913,5 +897,4 @@ module.exports = {
 	startGraphqlServer,
 	setUpTenantFiles,
 	writeSecretsFile,
-	createNotice,
 };


### PR DESCRIPTION
This PR is to enable edge url for all users.

## Description

As part of this PR we will show by default `Edge` and `Legacy` both the URLs to all the users. Add appropriate deprecation notice on `create`, `status` and `describe` commands.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-3315

## Motivation and Context

Needed for edge enablement.

## How Has This Been Tested?

Verified by making a local link of cli plugin.

## Screenshots (if appropriate):
(Create Mesh)
<img width="961" alt="image" src="https://github.com/user-attachments/assets/b0d9ae2d-4e75-43aa-a0f9-0a594aeb344a">


(Mesh Status)
<img width="807" alt="image" src="https://github.com/user-attachments/assets/cf6ef4e4-1f2f-4c72-b83f-bffad04b3bb4">

(Describe Mesh)
<img width="959" alt="image" src="https://github.com/user-attachments/assets/4f1a69b4-1b1b-4bde-8bfd-732cd9bc6453">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
