### PR TITLE
CEXT-3462 Local development masked error set to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.6.1-beta.2",
+	"version": "3.6.2-beta.1",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.6.2-beta.1",
+	"version": "3.7.0-beta.1",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/server.js
+++ b/src/server.js
@@ -95,6 +95,7 @@ const getYogaServer = async () => {
 			plugins: tenantMesh.plugins,
 			graphqlEndpoint: `/graphql`,
 			graphiql: true,
+			maskedErrors: false,
 			cors: corsOptions,
 			context: initialContext => ({
 				...initialContext,


### PR DESCRIPTION
To show appropriate error in local development when mesh is missing secrets.

## Description

Due to `maskedErrors` not set to `false` exact error from proxyHandler was not showing.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-3462

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Verified against local development `run` command by making a local link.

## Screenshots (if appropriate):

<img width="923" alt="image" src="https://github.com/user-attachments/assets/f6d7f5b6-1e05-4c54-91b4-ad17eddf9fb1">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
