### PR TITLE
chore: Update api key query parameter for direct calls to SMS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "3.9.2-beta1",
+	"version": "3.9.3",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"


### PR DESCRIPTION
PR(https://github.com/adobe/aio-cli-plugin-api-mesh/pull/185) to develop branch is being promoted to main

This is a backward compatible change so it will with the Adobe I/O Edge Gateway as well 

`curl https://graph.adobe.io/api-admin/health --header 'X-Api-Key: adobe-graph-prod'`
