### PR TITLE
Return mesh status while running status command programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "4.1.0-beta.2",
+	"version": "4.1.0-beta.3",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/commands/api-mesh/status.js
+++ b/src/commands/api-mesh/status.js
@@ -46,6 +46,8 @@ class StatusCommand extends Command {
 			this.log(''.padEnd(102, '*'));
 			await this.displayMeshStatus(mesh, imsOrgCode, projectId, workspaceId);
 			this.log(''.padEnd(102, '*'));
+
+			return mesh;
 		} catch (err) {
 			// Error occurred while fetching/displaying the mesh status
 			this.error(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Return mesh details in the status command.

Related PR: https://github.com/adobe-commerce/aio-cli-plugin-commerce/pull/4

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-4039

## Motivation and Context

Will be useful to apply retry logic in the commerce init command.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
