### PR TITLE
Fixed log commands by passing orgCode instead of orgId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "4.1.0-alpha",
+	"version": "5.0.0-alpha",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/commands/api-mesh/__tests__/log-get-bulk.test.js
+++ b/src/commands/api-mesh/__tests__/log-get-bulk.test.js
@@ -249,7 +249,7 @@ describe('GetBulkLogCommand', () => {
 
 		expect(initRequestId).toHaveBeenCalled();
 		expect(initSdk).toHaveBeenCalled();
-		expect(getMeshId).toHaveBeenCalledWith('orgId', 'projectId', 'workspaceId', 'workspaceName');
+		expect(getMeshId).toHaveBeenCalledWith('orgCode', 'projectId', 'workspaceId', 'workspaceName');
 		expect(getPresignedUrls).toHaveBeenCalledWith(
 			'orgCode',
 			'projectId',

--- a/src/commands/api-mesh/log-get-bulk.js
+++ b/src/commands/api-mesh/log-get-bulk.js
@@ -147,14 +147,14 @@ class GetBulkLogCommand extends Command {
 			return;
 		}
 		logger.info('Calling initSdk...');
-		const { imsOrgId, imsOrgCode, projectId, workspaceId, workspaceName } = await initSdk({
+		const { imsOrgCode, projectId, workspaceId, workspaceName } = await initSdk({
 			ignoreCache,
 		});
 
 		// Retrieve meshId
 		let meshId = null;
 		try {
-			meshId = await getMeshId(imsOrgId, projectId, workspaceId, workspaceName);
+			meshId = await getMeshId(imsOrgCode, projectId, workspaceId, workspaceName);
 		} catch (err) {
 			this.error(`Unable to get mesh ID: ${err.message}.`);
 		}

--- a/src/commands/api-mesh/log-get.js
+++ b/src/commands/api-mesh/log-get.js
@@ -31,13 +31,13 @@ class FetchLogsCommand extends Command {
 		const ignoreCache = flags.ignoreCache;
 		const rayId = args.rayId;
 
-		const { imsOrgId, imsOrgCode, projectId, workspaceId } = await initSdk({
+		const { imsOrgCode, projectId, workspaceId } = await initSdk({
 			ignoreCache,
 		});
 
 		let meshId = null;
 		try {
-			meshId = await getMeshId(imsOrgId, projectId, workspaceId, meshId);
+			meshId = await getMeshId(imsOrgCode, projectId, workspaceId, meshId);
 			if (!meshId) {
 				throw new Error('MeshIdNotFound');
 			}

--- a/src/commands/api-mesh/log-list.js
+++ b/src/commands/api-mesh/log-list.js
@@ -43,7 +43,7 @@ class ListLogsCommand extends Command {
 		let meshId = null;
 
 		try {
-			meshId = await getMeshId(imsOrgId, projectId, workspaceId, workspaceName);
+			meshId = await getMeshId(imsOrgCode, projectId, workspaceId, workspaceName);
 		} catch (err) {
 			this.error(
 				`Unable to get mesh ID. Check the details and try again. RequestId: ${global.requestId}`,

--- a/src/commands/api-mesh/source/install.js
+++ b/src/commands/api-mesh/source/install.js
@@ -38,6 +38,7 @@ class InstallCommand extends Command {
 		const ignoreCache = await flags.ignoreCache;
 		const {
 			imsOrgId,
+			imsOrgCode,
 			projectId,
 			workspaceId,
 			organizationName,
@@ -126,7 +127,7 @@ class InstallCommand extends Command {
 		}
 
 		try {
-			meshId = await getMeshId(imsOrgId, projectId, workspaceId, workspaceName);
+			meshId = await getMeshId(imsOrgCode, projectId, workspaceId, workspaceName);
 		} catch (err) {
 			this.error(
 				`Unable to get mesh ID. Please check the details and try again. RequestId: ${global.requestId}`,
@@ -140,7 +141,7 @@ class InstallCommand extends Command {
 		}
 
 		try {
-			const mesh = await getMesh(imsOrgId, projectId, workspaceId, meshId, workspaceName);
+			const mesh = await getMesh(imsOrgCode, projectId, workspaceId, meshId, workspaceName);
 
 			if (!mesh) {
 				this.error(


### PR DESCRIPTION
Updated using orgCode instead of orgId

## Description

Log related commands were not working because they were using `orgId`. Now because `getMeshId` is no more a devConsole call but a call to our SMS, we need to change it to use `orgCode` instead

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
