### PR TITLE
Cext 4156 cache invalidation command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "5.1.0-beta",
+	"version": "5.1.1-beta",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/commands/api-mesh/__tests__/cache-purge.test.js
+++ b/src/commands/api-mesh/__tests__/cache-purge.test.js
@@ -24,12 +24,6 @@ jest.mock('../../../helpers', () => ({
 	promptConfirm: jest.fn().mockResolvedValue(true),
 }));
 jest.mock('../../../lib/devConsole');
-jest.mock('chalk', () => ({
-	red: jest.fn(text => text),
-	underline: {
-		blue: jest.fn(text => text),
-	},
-}));
 const mockConsoleCLIInstance = {};
 const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' };
 const selectedProject = { id: '5678', title: 'Project01' };
@@ -87,31 +81,37 @@ describe('cache purge command tests', () => {
 		jest.restoreAllMocks();
 	});
 
-	test('should fail if purgeAllAction is missing', async () => {
+	test('should fail if all flag is missing', async () => {
 		parseSpy.mockResolvedValueOnce({
 			args: {},
 			flags: {
 				ignoreCache: mockIgnoreCacheFlag,
 				autoConfirmAction: mockAutoApproveAction,
-				purgeAllAction: Promise.resolve(false),
+				all: Promise.resolve(false),
 			},
 		});
-		await commandInstance.run();
-		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
-		[
-		  [
-		    "Missing required args.",
-		  ],
-		  [
-		    "Showing help:",
-		  ],
-		]
-	`);
-		expect(commandInstance.config.runCommand).toHaveBeenCalledWith('help', [
-			'api-mesh:cache:purge',
-		]);
 
-		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+		const runResult = CachePurgeCommand.run();
+
+		return runResult.catch(err => {
+			expect(err.message).toMatchInlineSnapshot(
+				`"Unable to purge cache. If the error persists please contact support. RequestId: dummy_request_id"`,
+			);
+			expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Unable to purge cache. If the error persists please contact support. RequestId: dummy_request_id",
+			  ],
+			]
+		`);
+			expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Unable to purge cache. If the error persists please contact support. RequestId: dummy_request_id",
+			  ],
+			]
+		`);
+		});
 	});
 
 	test('should fail if unable to get mesh ID', async () => {
@@ -120,7 +120,7 @@ describe('cache purge command tests', () => {
 			flags: {
 				ignoreCache: mockIgnoreCacheFlag,
 				autoConfirmAction: mockAutoApproveAction,
-				purgeAllAction: Promise.resolve(true),
+				all: Promise.resolve(true),
 			},
 		});
 		getMeshId.mockResolvedValueOnce(null);
@@ -148,7 +148,7 @@ describe('cache purge command tests', () => {
 			flags: {
 				ignoreCache: mockIgnoreCacheFlag,
 				autoConfirmAction: mockAutoApproveAction,
-				purgeAllAction: Promise.resolve(true),
+				all: Promise.resolve(true),
 			},
 		});
 		promptConfirm.mockResolvedValueOnce(false);
@@ -172,7 +172,7 @@ describe('cache purge command tests', () => {
 			flags: {
 				ignoreCache: mockIgnoreCacheFlag,
 				autoConfirmAction: Promise.resolve(true),
-				purgeAllAction: Promise.resolve(true),
+				all: Promise.resolve(true),
 			},
 		});
 		cachePurge.mockResolvedValueOnce({ success: true });
@@ -201,7 +201,7 @@ describe('cache purge command tests', () => {
 			flags: {
 				ignoreCache: mockIgnoreCacheFlag,
 				autoConfirmAction: Promise.resolve(false),
-				purgeAllAction: Promise.resolve(true),
+				all: Promise.resolve(true),
 			},
 		});
 		cachePurge.mockRejectedValueOnce(new Error('cache purge failed'));
@@ -235,7 +235,7 @@ describe('cache purge command tests', () => {
 			flags: {
 				ignoreCache: mockIgnoreCacheFlag,
 				autoConfirmAction: Promise.resolve(true),
-				purgeAllAction: Promise.resolve(true),
+				all: Promise.resolve(true),
 			},
 		});
 		cachePurge.mockResolvedValueOnce({ success: true });

--- a/src/commands/api-mesh/__tests__/cache-purge.test.js
+++ b/src/commands/api-mesh/__tests__/cache-purge.test.js
@@ -1,0 +1,262 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+jest.mock('axios');
+jest.mock('@adobe/aio-lib-env');
+jest.mock('@adobe/aio-lib-ims');
+jest.mock('@adobe/aio-cli-lib-console');
+jest.mock('@adobe/aio-cli-lib-console', () => ({
+	init: jest.fn().mockResolvedValue(mockConsoleCLIInstance),
+	cleanStdOut: jest.fn(),
+}));
+jest.mock('../../../helpers', () => ({
+	initSdk: jest.fn().mockResolvedValue({}),
+	initRequestId: jest.fn().mockResolvedValue({}),
+	promptConfirm: jest.fn().mockResolvedValue(true),
+}));
+jest.mock('../../../lib/devConsole');
+
+const mockConsoleCLIInstance = {};
+
+const selectedOrg = { id: '1234', code: 'CODE1234@AdobeOrg', name: 'ORG01', type: 'entp' };
+
+const selectedProject = { id: '5678', title: 'Project01' };
+
+const selectedWorkspace = { id: '123456789', title: 'Workspace01' };
+
+const CachePurgeCommand = require('../cache/purge');
+const { initSdk, initRequestId, promptConfirm } = require('../../../helpers');
+const {
+	getMeshId,
+	deleteMesh,
+	getApiKeyCredential,
+	unsubscribeCredentialFromMeshService,
+	cachePurge,
+} = require('../../../lib/devConsole');
+
+let logSpy = null;
+let errorLogSpy = null;
+
+let parseSpy = null;
+
+const mockIgnoreCacheFlag = Promise.resolve(true);
+const mockAutoApproveAction = Promise.resolve(false);
+
+describe('cache purge command tests', () => {
+	beforeEach(() => {
+		initSdk.mockResolvedValue({
+			imsOrgCode: selectedOrg.code,
+			projectId: selectedProject.id,
+			workspaceId: selectedWorkspace.id,
+		});
+
+		global.requestId = 'dummy_request_id';
+
+		logSpy = jest.spyOn(CachePurgeCommand.prototype, 'log');
+		errorLogSpy = jest.spyOn(CachePurgeCommand.prototype, 'error');
+
+		getMeshId.mockResolvedValue('mesh_id');
+		deleteMesh.mockResolvedValue({ status: 'success' });
+		getApiKeyCredential.mockResolvedValue({
+			id_integration: 'dummy_integration_id',
+			client_id: 'dummy_client_id',
+		});
+		unsubscribeCredentialFromMeshService.mockResolvedValue(['dummy_service']);
+
+		parseSpy = jest.spyOn(CachePurgeCommand.prototype, 'parse');
+		parseSpy.mockResolvedValue({
+			args: {},
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
+			},
+		});
+	});
+
+	// afterEach(() => {
+	// 	jest.restoreAllMocks();
+	// });
+
+	test('should fail if cachePurgeAction is missing', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: {},
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
+				cachePurgeAction: Promise.resolve(false),
+			},
+		});
+
+		const runResult = CachePurgeCommand.run();
+
+		return runResult.catch(err => {
+			expect(err.message).toMatchInlineSnapshot(
+				`"Missing required args. Run aio api-mesh:cache:purge --help for more info."`,
+			);
+			expect(logSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+			expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+			[
+			  [
+			    "Missing required args. Run aio api-mesh:cache:purge --help for more info.",
+			  ],
+			]
+		`);
+		});
+	});
+
+	test('should fail if unable to get mesh ID', async () => {
+		getMeshId.mockResolvedValueOnce(null);
+
+		const runResult = CachePurgeCommand.run();
+
+		return runResult.catch(err => {
+			expect(err.message).toMatchInlineSnapshot(
+				`"Unable to purge cache. No mesh found for Org(CODE1234@AdobeOrg) -> Project(5678) -> Workspace(123456789). Check the details and try again."`,
+			);
+			expect(logSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+			expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+			                [
+			                  [
+			                    "Unable to purge cache. No mesh found for Org(CODE1234@AdobeOrg) -> Project(5678) -> Workspace(123456789). Check the details and try again.",
+			                  ],
+			                ]
+		            `);
+		});
+	});
+
+	test('should not purge cache if user prompt returns false', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: {},
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: mockAutoApproveAction,
+				cachePurgeAction: Promise.resolve(true),
+			},
+		});
+		promptConfirm.mockResolvedValueOnce(false);
+
+		const runResult = await CachePurgeCommand.run();
+
+		expect(runResult).toBe('Cache purge cancelled');
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Cache purge cancelled",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+	});
+
+	test('should not ask for prompt if autoConfirmAction is set', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: {},
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: Promise.resolve(true),
+				cachePurgeAction: Promise.resolve(true),
+			},
+		});
+		cachePurge.mockResolvedValueOnce({ success: true });
+		const runResult = await CachePurgeCommand.run();
+
+		expect(runResult).toMatchInlineSnapshot(`
+		            {
+		              "success": true,
+		            }
+	        `);
+		expect(promptConfirm).not.toHaveBeenCalled();
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		            [
+		              [
+		                "Successfully purged cache for mesh %s",
+		                "mesh_id",
+		              ],
+		            ]
+	        `);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+	});
+
+	test('should fail if cache purge fails', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: {},
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: Promise.resolve(false),
+				cachePurgeAction: Promise.resolve(true),
+			},
+		});
+		cachePurge.mockRejectedValueOnce(new Error('cache purge failed'));
+
+		const runResult = CachePurgeCommand.run();
+
+		await expect(runResult).rejects.toEqual(
+			new Error(
+				'Unable to purge cache. If the error persists please contact support. RequestId: dummy_request_id',
+			),
+		);
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "cache purge failed",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Unable to purge cache. If the error persists please contact support. RequestId: dummy_request_id",
+		  ],
+		]
+	`);
+	});
+
+	test('should purge cache if correct args are provided', async () => {
+		parseSpy.mockResolvedValueOnce({
+			args: {},
+			flags: {
+				ignoreCache: mockIgnoreCacheFlag,
+				autoConfirmAction: Promise.resolve(true),
+				cachePurgeAction: Promise.resolve(true),
+			},
+		});
+		cachePurge.mockResolvedValueOnce({ success: true });
+		const runResult = await CachePurgeCommand.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(runResult).toMatchInlineSnapshot(`
+		{
+		  "success": true,
+		}
+	`);
+		expect(cachePurge.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "CODE1234@AdobeOrg",
+		    "5678",
+		    "123456789",
+		    "mesh_id",
+		  ],
+		]
+	`);
+
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+		[
+		  [
+		    "Successfully purged cache for mesh %s",
+		    "mesh_id",
+		  ],
+		]
+	`);
+		expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+	});
+});

--- a/src/commands/api-mesh/__tests__/cache-purge.test.js
+++ b/src/commands/api-mesh/__tests__/cache-purge.test.js
@@ -39,17 +39,12 @@ const {
 } = require('../../../lib/devConsole');
 let logSpy = null;
 let errorLogSpy = null;
-let commandInstance;
 let parseSpy = null;
 const mockIgnoreCacheFlag = Promise.resolve(true);
 const mockAutoApproveAction = Promise.resolve(false);
 
 describe('cache purge command tests', () => {
 	beforeEach(() => {
-		commandInstance = new CachePurgeCommand([], {});
-		commandInstance.config = commandInstance.config || {};
-		commandInstance.config.runCommand = jest.fn(() => Promise.resolve());
-
 		initSdk.mockResolvedValue({
 			imsOrgCode: selectedOrg.code,
 			projectId: selectedProject.id,
@@ -68,13 +63,6 @@ describe('cache purge command tests', () => {
 		unsubscribeCredentialFromMeshService.mockResolvedValue(['dummy_service']);
 
 		parseSpy = jest.spyOn(CachePurgeCommand.prototype, 'parse');
-		parseSpy.mockResolvedValue({
-			args: {},
-			flags: {
-				ignoreCache: mockIgnoreCacheFlag,
-				autoConfirmAction: mockAutoApproveAction,
-			},
-		});
 	});
 
 	afterEach(() => {

--- a/src/commands/api-mesh/cache/purge.js
+++ b/src/commands/api-mesh/cache/purge.js
@@ -58,7 +58,7 @@ class CachePurgeCommand extends Command {
 				`Unable to purge cache. No mesh found for Org(${imsOrgCode}) -> Project(${projectId}) -> Workspace(${workspaceId}). Check the details and try again.`,
 			);
 		}
-		let shouldContinue = autoConfirmAction ? true : false;
+		let shouldContinue = !!autoConfirmAction;
 		if (!autoConfirmAction) {
 			shouldContinue = await promptConfirm(`Cache will purge ALL data. Do you wish to continue?`);
 		}

--- a/src/commands/api-mesh/cache/purge.js
+++ b/src/commands/api-mesh/cache/purge.js
@@ -22,7 +22,7 @@ class CachePurgeCommand extends Command {
 	static flags = {
 		ignoreCache: ignoreCacheFlag,
 		autoConfirmAction: autoConfirmActionFlag,
-        cachePurgeAction: cachePurgeActionFlag,
+		cachePurgeAction: cachePurgeActionFlag,
 	};
 
 	async run() {
@@ -34,11 +34,11 @@ class CachePurgeCommand extends Command {
 
 		const ignoreCache = await flags.ignoreCache;
 		const autoConfirmAction = await flags.autoConfirmAction;
-        const cachePurgeAction = await flags.cachePurgeAction;
+		const cachePurgeAction = await flags.cachePurgeAction;
 
-		if(!cachePurgeAction) {
+		if (!cachePurgeAction) {
 			this.error('Missing required args. Run aio api-mesh cache:purge --help for more info.');
-		} 
+		}
 
 		const { imsOrgCode, projectId, workspaceId } = await initSdk({
 			ignoreCache,
@@ -56,12 +56,10 @@ class CachePurgeCommand extends Command {
 
 		if (meshId) {
 			let shouldContinue = true;
-            console.log(cachePurgeAction);
-            if(cachePurgeAction && !autoConfirmAction) {
-                shouldContinue = await promptConfirm(
-                    `Cache will purge ALL data. Do you wish to continue?`,
-                );
-            } 
+			console.log(cachePurgeAction);
+			if (cachePurgeAction && !autoConfirmAction) {
+				shouldContinue = await promptConfirm(`Cache will purge ALL data. Do you wish to continue?`);
+			}
 
 			if (shouldContinue) {
 				try {
@@ -72,7 +70,9 @@ class CachePurgeCommand extends Command {
 
 						return cachePurgeResponse;
 					} else {
-						throw new Error(`Unable to purge cache. If the error persists please contact support. RequestId: ${global.requestId}`);
+						throw new Error(
+							`Unable to purge cache. If the error persists please contact support. RequestId: ${global.requestId}`,
+						);
 					}
 				} catch (error) {
 					this.log(error.message);

--- a/src/commands/api-mesh/cache/purge.js
+++ b/src/commands/api-mesh/cache/purge.js
@@ -36,10 +36,6 @@ class CachePurgeCommand extends Command {
 		const autoConfirmAction = await flags.autoConfirmAction;
 		const cachePurgeAction = await flags.cachePurgeAction;
 
-		if (!cachePurgeAction) {
-			this.error('Missing required args. Run aio api-mesh cache:purge --help for more info.');
-		}
-
 		const { imsOrgCode, projectId, workspaceId } = await initSdk({
 			ignoreCache,
 		});
@@ -56,7 +52,9 @@ class CachePurgeCommand extends Command {
 
 		if (meshId) {
 			let shouldContinue = true;
-			console.log(cachePurgeAction);
+			if (!cachePurgeAction) {
+				this.error('Missing required args. Run aio api-mesh:cache:purge --help for more info.');
+			}
 			if (cachePurgeAction && !autoConfirmAction) {
 				shouldContinue = await promptConfirm(`Cache will purge ALL data. Do you wish to continue?`);
 			}

--- a/src/commands/api-mesh/cache/purge.js
+++ b/src/commands/api-mesh/cache/purge.js
@@ -13,8 +13,13 @@ const { Command } = require('@oclif/command');
 
 const logger = require('../../../classes/logger');
 const { initSdk, initRequestId, promptConfirm } = require('../../../helpers');
-const { ignoreCacheFlag, autoConfirmActionFlag, cachePurgeActionFlag } = require('../../../utils');
+const {
+	ignoreCacheFlag,
+	autoConfirmActionFlag,
+	cachePurgeAllActionFlag,
+} = require('../../../utils');
 const { getMeshId, cachePurge } = require('../../../lib/devConsole');
+const chalk = require('chalk');
 
 require('dotenv').config();
 
@@ -22,7 +27,7 @@ class CachePurgeCommand extends Command {
 	static flags = {
 		ignoreCache: ignoreCacheFlag,
 		autoConfirmAction: autoConfirmActionFlag,
-		cachePurgeAction: cachePurgeActionFlag,
+		purgeAllAction: cachePurgeAllActionFlag,
 	};
 
 	async run() {
@@ -34,7 +39,7 @@ class CachePurgeCommand extends Command {
 
 		const ignoreCache = await flags.ignoreCache;
 		const autoConfirmAction = await flags.autoConfirmAction;
-		const cachePurgeAction = await flags.cachePurgeAction;
+		const purgeAllAction = await flags.purgeAllAction;
 
 		const { imsOrgCode, projectId, workspaceId } = await initSdk({
 			ignoreCache,
@@ -52,10 +57,13 @@ class CachePurgeCommand extends Command {
 
 		if (meshId) {
 			let shouldContinue = true;
-			if (!cachePurgeAction) {
-				this.error('Missing required args. Run aio api-mesh:cache:purge --help for more info.');
+			if (!purgeAllAction) {
+				this.log(chalk.red('Missing required args.'));
+				this.log(chalk.underline.blue('Showing help:'));
+				this.config.runCommand('help', ['api-mesh:cache:purge']);
+				return;
 			}
-			if (cachePurgeAction && !autoConfirmAction) {
+			if (purgeAllAction && !autoConfirmAction) {
 				shouldContinue = await promptConfirm(`Cache will purge ALL data. Do you wish to continue?`);
 			}
 

--- a/src/commands/api-mesh/cache/purge.js
+++ b/src/commands/api-mesh/cache/purge.js
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Command } = require('@oclif/command');
+
+const logger = require('../../../classes/logger');
+const { initSdk, initRequestId, promptConfirm } = require('../../../helpers');
+const { ignoreCacheFlag, autoConfirmActionFlag, cachePurgeActionFlag } = require('../../../utils');
+const { getMeshId, cachePurge } = require('../../../lib/devConsole');
+
+require('dotenv').config();
+
+class CachePurgeCommand extends Command {
+	static flags = {
+		ignoreCache: ignoreCacheFlag,
+		autoConfirmAction: autoConfirmActionFlag,
+        cachePurgeAction: cachePurgeActionFlag,
+	};
+
+	async run() {
+		await initRequestId();
+
+		logger.info(`RequestId: ${global.requestId}`);
+
+		const { flags } = await this.parse(CachePurgeCommand);
+
+		const ignoreCache = await flags.ignoreCache;
+		const autoConfirmAction = await flags.autoConfirmAction;
+        const cachePurgeAction = await flags.cachePurgeAction;
+
+		if(!cachePurgeAction) {
+			this.error('Missing required args. Run aio api-mesh cache:purge --help for more info.');
+		} 
+
+		const { imsOrgCode, projectId, workspaceId } = await initSdk({
+			ignoreCache,
+		});
+
+		let meshId = null;
+
+		try {
+			meshId = await getMeshId(imsOrgCode, projectId, workspaceId);
+		} catch (err) {
+			this.error(
+				`Unable to get mesh ID. Please check the details and try again. RequestId: ${global.requestId}`,
+			);
+		}
+
+		if (meshId) {
+			let shouldContinue = true;
+            console.log(cachePurgeAction);
+            if(cachePurgeAction && !autoConfirmAction) {
+                shouldContinue = await promptConfirm(
+                    `Cache will purge ALL data. Do you wish to continue?`,
+                );
+            } 
+
+			if (shouldContinue) {
+				try {
+					const cachePurgeResponse = await cachePurge(imsOrgCode, projectId, workspaceId, meshId);
+
+					if (cachePurgeResponse) {
+						this.log('Successfully purged cache for mesh %s', meshId);
+
+						return cachePurgeResponse;
+					} else {
+						throw new Error(`Unable to purge cache. If the error persists please contact support. RequestId: ${global.requestId}`);
+					}
+				} catch (error) {
+					this.log(error.message);
+
+					this.error(
+						`Unable to purge cache. If the error persists please contact support. RequestId: ${global.requestId}`,
+					);
+				}
+			} else {
+				this.log('Cache purge cancelled');
+
+				return 'Cache purge cancelled';
+			}
+		} else {
+			this.error(
+				`Unable to purge cache. No mesh found for Org(${imsOrgCode}) -> Project(${projectId}) -> Workspace(${workspaceId}). Check the details and try again.`,
+			);
+		}
+	}
+}
+
+CachePurgeCommand.description = 'Cache purge for a given mesh';
+
+module.exports = CachePurgeCommand;

--- a/src/lib/devConsole.js
+++ b/src/lib/devConsole.js
@@ -521,6 +521,93 @@ const deleteMesh = async (organizationId, projectId, workspaceId, meshId) => {
 	}
 };
 
+const cachePurge = async (organizationId, projectId, workspaceId, meshId) => {
+	const { accessToken } = await getDevConsoleConfig();
+	const config = {
+		method: 'post',
+		url: `${SMS_BASE_URL}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/meshes/${meshId}/cache/purge`,
+		headers: {
+			'Authorization': `Bearer ${accessToken}`,
+			'Content-Type': 'application/json',
+			'x-request-id': global.requestId,
+			'x-api-key': SMS_API_KEY,
+		},
+	};
+
+	logger.info(
+		'Initiating cache purge %s',
+		`${SMS_BASE_URL}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/meshes/${meshId}/cache/purge`,
+	);
+
+	try {
+		const response = await axios(config);
+
+		logger.info('Response from cache purge %s', response.status);
+
+		if (response && response.status === 200) {
+			return response;
+		} else {
+			// Non 204 response received
+			logger.error(
+				`Something went wrong: ${objToString(
+					response,
+					['data'],
+					'Unable to purge cache',
+				)}. Received ${response.status} response instead of 204`,
+			);
+
+			throw new Error(
+				`Something went wrong: ${objToString(response, ['data'], 'Unable to purge cache')}`,
+			);
+		}
+	} catch (error) {
+		logger.info('Response from cache purge %s', error.response.status);
+
+		if (error.response.status === 404) {
+			// The request was made and the server responded with a 404 status code
+			logger.error('Mesh not found');
+
+			throw new Error('Mesh not found');
+		} else if (error.response && error.response.data) {
+			// The request was made and the server responded with an unsupported status code
+			logger.error(
+				'Error in cache purge. Response: %s',
+				objToString(error, ['response', 'data'], 'Unable to purge cache'),
+			);
+
+			if (error.response.data.messages) {
+				const message = objToString(
+					error,
+					['response', 'data', 'messages', '0', 'message'],
+					'Unable to purge cache',
+				);
+
+				throw new Error(message);
+			} else if (error.response.data.message) {
+				const message = objToString(
+					error,
+					['response', 'data', 'message'],
+					'Unable to purge cache',
+				);
+
+				throw new Error(message);
+			} else {
+				const message = objToString(error, ['response', 'data'], 'Unable to purge cache');
+
+				throw new Error(message);
+			}
+		} else {
+			// The request was made but no response was received
+			logger.error(
+				'Error while purge cache. No response received from the server: %s',
+				objToString(error, [], 'Unable to purge cache'),
+			);
+
+			throw new Error('Unable to purge cache from Schema Management Service: %s', error.message);
+		}
+	}
+};
+
 const getMeshId = async (organizationCode, projectId, workspaceId, workspaceName) => {
 	const { accessToken } = await getDevConsoleConfig();
 	logger.info('Initiating Mesh ID request');
@@ -1133,4 +1220,5 @@ module.exports = {
 	getPublicEncryptionKey,
 	getPresignedUrls,
 	getLogsByRayId,
+	cachePurge,
 };

--- a/src/lib/devConsole.js
+++ b/src/lib/devConsole.js
@@ -547,13 +547,13 @@ const cachePurge = async (organizationId, projectId, workspaceId, meshId) => {
 		if (response && response.status === 200) {
 			return response;
 		} else {
-			// Non 204 response received
+			// Non 200 response received
 			logger.error(
 				`Something went wrong: ${objToString(
 					response,
 					['data'],
 					'Unable to purge cache',
-				)}. Received ${response.status} response instead of 204`,
+				)}. Received ${response.status} response instead of 200`,
 			);
 
 			throw new Error(

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,6 +35,14 @@ const autoConfirmActionFlag = Flags.boolean({
 	default: false,
 });
 
+const cachePurgeActionFlag = Flags.boolean({
+	char: 'a',
+	description:
+		'Auto confirm action prompt for cache purge.',
+	default: false,
+	required: true,
+});
+
 const jsonFlag = Flags.boolean({
 	description: 'Output JSON',
 	default: false,
@@ -621,4 +629,5 @@ module.exports = {
 	endTimeFlag,
 	logFilenameFlag,
 	suggestCorrectedDateFormat,
+	cachePurgeActionFlag,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,9 +35,10 @@ const autoConfirmActionFlag = Flags.boolean({
 	default: false,
 });
 
-const cachePurgeActionFlag = Flags.boolean({
+const cachePurgeAllActionFlag = Flags.boolean({
 	char: 'a',
-	description: 'Auto confirm action prompt for cache purge. Cache will purge ALL data',
+	description: 'Purge all cache. CLI will purge all cache data.',
+	helpLabel: '-a, --all',
 	default: false,
 	required: true,
 });
@@ -628,5 +629,5 @@ module.exports = {
 	endTimeFlag,
 	logFilenameFlag,
 	suggestCorrectedDateFormat,
-	cachePurgeActionFlag,
+	cachePurgeAllActionFlag,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,8 +37,7 @@ const autoConfirmActionFlag = Flags.boolean({
 
 const cachePurgeActionFlag = Flags.boolean({
 	char: 'a',
-	description:
-		'Auto confirm action prompt for cache purge.',
+	description: 'Auto confirm action prompt for cache purge.',
 	default: false,
 	required: true,
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,8 +38,6 @@ const autoConfirmActionFlag = Flags.boolean({
 const cachePurgeAllActionFlag = Flags.boolean({
 	char: 'a',
 	description: 'Purge all cache. CLI will purge all cache data.',
-	helpLabel: '-a, --all',
-	default: false,
 	required: true,
 });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,7 +37,7 @@ const autoConfirmActionFlag = Flags.boolean({
 
 const cachePurgeActionFlag = Flags.boolean({
 	char: 'a',
-	description: 'Auto confirm action prompt for cache purge.',
+	description: 'Auto confirm action prompt for cache purge. Cache will purge ALL data',
 	default: false,
 	required: true,
 });


### PR DESCRIPTION
Cache purge CLI command

## Description

This PR provides feature of new cli command that can be used to purge all cache.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This provides a user friendly way to user to purge cache.

## Usage

```
aio api-mesh cache purge -a
aio api-mesh cache purge --all
aio api-mesh:cache:purge -a
aio api-mesh:cache:purge --all
```

## How Has This Been Tested?

Tested by making a local link of CLI plugin. As the API is deployed on stage, so verified against stage with a local link.

## Screenshots (if appropriate):

**Required argument not provided:**

<img width="561" alt="image" src="https://github.com/user-attachments/assets/65794f69-4045-4408-8364-6b67902f44d0" />

**Required argument provided with prompt confirm:**

<img width="589" alt="Screenshot 2025-03-04 at 8 57 05 PM" src="https://github.com/user-attachments/assets/aac7cad0-fc7a-4025-a51c-610d3aa43734" />


**Required argument passed with auto-confirmation prompt:**

<img width="589" alt="Screenshot 2025-03-04 at 8 59 24 PM" src="https://github.com/user-attachments/assets/8811b264-2f31-4515-abde-53d7f0e89c17" />

**User decides not to purge cache:**

<img width="595" alt="Screenshot 2025-03-04 at 9 02 03 PM" src="https://github.com/user-attachments/assets/102d3049-da87-4f75-9e21-6d170b91e05c" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
