### PR TITLE
Cext 4219

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
 		"jsmin": "1.0.1",
 		"json-interpolate": "^1.0.3",
 		"lru-cache": "^7.14.1",
+		"ms": "^2.1.3",
 		"node-clipboardy": "^1.0.3",
 		"node-fetch": "2.6.1",
 		"pino": "^9.5.0",

--- a/src/commands/api-mesh/__tests__/log-get-bulk.test.js
+++ b/src/commands/api-mesh/__tests__/log-get-bulk.test.js
@@ -90,7 +90,7 @@ describe('GetBulkLogCommand', () => {
 
 		const command = new GetBulkLogCommand([], {});
 		await expect(command.run()).rejects.toThrow(
-			'Max duration between startTime and endTime should be 30 minutes. Current duration is 0 hours 45 minutes and 0 seconds.',
+			'The maximum duration between startTime and endTime is 30 minutes. The current duration is 0 hours 45 minutes and 0 seconds.',
 		);
 	});
 
@@ -445,7 +445,7 @@ describe('GetBulkLogCommand with --past and --from flags', () => {
 
 		const command = new GetBulkLogCommand([], {});
 		await expect(command.run()).rejects.toThrow(
-			'Invalid format. Past time window should be in minutes, e.g., "20 mins", "15 minutes".',
+			'Invalid format. The past time window should be in minutes, for example, "20 mins", "15 minutes".',
 		);
 	});
 
@@ -500,7 +500,7 @@ describe('validateDateTimeRange', () => {
 		{
 			startTime: '2025-03-09T12:00:00Z',
 			endTime: '2025-03-09T12:00:00Z',
-			error: 'The minimum duration is minutes. Current duration is 0 minutes.',
+			error: 'The minimum duration is 1 minutes. The current duration is 0 minutes.',
 		},
 		{
 			startTime: '2025-03-09T12:30:00Z',

--- a/src/commands/api-mesh/__tests__/log-get-bulk.test.js
+++ b/src/commands/api-mesh/__tests__/log-get-bulk.test.js
@@ -385,7 +385,7 @@ describe('GetBulkLogCommand with --past and --from flags', () => {
 
 		const command = new GetBulkLogCommand([], {});
 		await expect(command.run()).rejects.toThrow(
-			'Found invalid date components passed in --from. Check and correct the date.',
+			'Invalid date components passed in --from. Correct the date.',
 		);
 	});
 
@@ -485,7 +485,7 @@ describe('validateDateTimeRange', () => {
 			startTime: '2025-03-09T12:00:00Z',
 			endTime: '2025-03-09T12:45:00Z',
 			error:
-				'Max duration between startTime and endTime should be 30 minutes. Current duration is 0 hours 45 minutes and 0 seconds.',
+				'The maximum duration between startTime and endTime is 30 minutes. The current duration is 0 hours 45 minutes and 0 seconds.',
 		},
 		{
 			startTime: new Date().toISOString(),
@@ -500,7 +500,7 @@ describe('validateDateTimeRange', () => {
 		{
 			startTime: '2025-03-09T12:00:00Z',
 			endTime: '2025-03-09T12:00:00Z',
-			error: 'Minimum duration should be 1 minutes. Current duration is 0 minutes.',
+			error: 'The minimum duration is minutes. Current duration is 0 minutes.',
 		},
 		{
 			startTime: '2025-03-09T12:30:00Z',
@@ -554,7 +554,7 @@ describe('parsePastDuration', () => {
 		'throws an error for invalid past duration format "%s"',
 		invalidPastDuration => {
 			expect(() => parsePastDuration(invalidPastDuration)).toThrow(
-				'Invalid format. Past time window should be in minutes, e.g., "20 mins", "15 minutes".',
+				'Invalid format. The past time window should be in minutes, for example, "20 mins", "15 minutes".',
 			);
 		},
 	);

--- a/src/commands/api-mesh/__tests__/log-get-bulk.test.js
+++ b/src/commands/api-mesh/__tests__/log-get-bulk.test.js
@@ -303,7 +303,7 @@ describe('GetBulkLogCommand with --past and --from flags', () => {
 		parseSpy = jest.spyOn(GetBulkLogCommand.prototype, 'parse').mockResolvedValue({
 			flags: {
 				past: '20mins',
-				from: '2025-03-10:12:00:00',
+				from: '2025-03-09:12:00:00',
 				filename: 'test.csv',
 				ignoreCache: false,
 			},

--- a/src/commands/api-mesh/__tests__/log-get-bulk.test.js
+++ b/src/commands/api-mesh/__tests__/log-get-bulk.test.js
@@ -3,7 +3,11 @@ const path = require('path');
 const GetBulkLogCommand = require('../log-get-bulk');
 const { initRequestId, initSdk, promptConfirm } = require('../../../helpers');
 const { getMeshId, getPresignedUrls } = require('../../../lib/devConsole');
-const { suggestCorrectedDateFormat } = require('../../../utils');
+const {
+	suggestCorrectedDateFormat,
+	validateDateTimeRange,
+	parsePastDuration,
+} = require('../../../utils');
 
 jest.mock('fs');
 jest.mock('axios');
@@ -288,6 +292,252 @@ describe('GetBulkLogCommand startTime and endTime validation', () => {
 		(inputDate, expectedOutput) => {
 			const correctedDate = suggestCorrectedDateFormat(inputDate);
 			expect(correctedDate).toBe(expectedOutput);
+		},
+	);
+});
+
+describe('GetBulkLogCommand with --past and --from flags', () => {
+	let parseSpy;
+
+	beforeEach(() => {
+		parseSpy = jest.spyOn(GetBulkLogCommand.prototype, 'parse').mockResolvedValue({
+			flags: {
+				past: '20mins',
+				from: '2025-03-10:12:00:00',
+				filename: 'test.csv',
+				ignoreCache: false,
+			},
+		});
+
+		initSdk.mockResolvedValue({
+			imsOrgId: 'orgId',
+			imsOrgCode: 'orgCode',
+			projectId: 'projectId',
+			workspaceId: 'workspaceId',
+			workspaceName: 'workspaceName',
+		});
+		getMeshId.mockResolvedValue('meshId');
+		getPresignedUrls.mockResolvedValue({
+			presignedUrls: [{ key: 'log1.csv', url: 'http://example.com/someHash' }],
+			totalSize: 2048,
+		});
+		promptConfirm.mockResolvedValue(true);
+		global.requestId = 'dummy_request_id';
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	test('runs with valid --past and --from flags', async () => {
+		fs.existsSync.mockReturnValue(true);
+		fs.statSync.mockReturnValue({ size: 0 });
+
+		const mockWriteStream = {
+			write: jest.fn(),
+			end: jest.fn(),
+			on: jest.fn((event, callback) => {
+				if (event === 'finish') {
+					callback();
+				}
+			}),
+		};
+		fs.createWriteStream.mockReturnValue(mockWriteStream);
+
+		const command = new GetBulkLogCommand([], {});
+		await command.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(initSdk).toHaveBeenCalled();
+		expect(getMeshId).toHaveBeenCalledWith('orgCode', 'projectId', 'workspaceId', 'workspaceName');
+		expect(getPresignedUrls).toHaveBeenCalledWith(
+			'orgCode',
+			'projectId',
+			'workspaceId',
+			'meshId',
+			expect.any(String),
+			expect.any(String),
+		);
+		expect(fs.createWriteStream).toHaveBeenCalledWith(path.resolve(process.cwd(), 'test.csv'), {
+			flags: 'a',
+		});
+		expect(mockWriteStream.write).toHaveBeenCalled();
+		expect(mockWriteStream.end).toHaveBeenCalled();
+	});
+
+	test('throws an error with invalid --from date components', async () => {
+		parseSpy.mockResolvedValueOnce({
+			flags: {
+				past: '20mins',
+				from: '2025-13-01:25:61:61',
+				filename: 'test.csv',
+				ignoreCache: false,
+			},
+		});
+
+		const command = new GetBulkLogCommand([], {});
+		await expect(command.run()).rejects.toThrow(
+			'Found invalid date components passed in --from. Check and correct the date.',
+		);
+	});
+
+	test('throws an error with invalid --from date format', async () => {
+		parseSpy.mockResolvedValueOnce({
+			flags: {
+				past: '15mins',
+				from: '2025:03:01:15:00:00',
+				filename: 'test.csv',
+				ignoreCache: false,
+			},
+		});
+
+		const command = new GetBulkLogCommand([], {});
+		await expect(command.run()).rejects.toThrow(
+			'Invalid format. Use the format YYYY-MM-DD:HH:MM:SS for --from.',
+		);
+	});
+
+	test('runs with valid --past flag without --from', async () => {
+		parseSpy.mockResolvedValueOnce({
+			flags: {
+				past: '15mins',
+				filename: 'test.csv',
+				ignoreCache: false,
+			},
+		});
+
+		fs.existsSync.mockReturnValue(true);
+		fs.statSync.mockReturnValue({ size: 0 });
+
+		const command = new GetBulkLogCommand([], {});
+		await command.run();
+
+		expect(initRequestId).toHaveBeenCalled();
+		expect(initSdk).toHaveBeenCalled();
+		expect(getMeshId).toHaveBeenCalledWith('orgCode', 'projectId', 'workspaceId', 'workspaceName');
+		expect(getPresignedUrls).toHaveBeenCalledWith(
+			'orgCode',
+			'projectId',
+			'workspaceId',
+			'meshId',
+			expect.any(String),
+			expect.any(String),
+		);
+	});
+
+	test('throws an error with edge case for --past duration', async () => {
+		parseSpy.mockResolvedValueOnce({
+			flags: {
+				past: '0s',
+				from: '2025-03-10:12:00:00',
+				filename: 'test.csv',
+				ignoreCache: false,
+			},
+		});
+
+		const command = new GetBulkLogCommand([], {});
+		await expect(command.run()).rejects.toThrow(
+			'Invalid format. Past time window should be in minutes, e.g., "20 mins", "15 minutes".',
+		);
+	});
+
+	test('runs with edge case for --from date', async () => {
+		parseSpy.mockResolvedValueOnce({
+			flags: {
+				past: '15mins',
+				from: '2025-01-01:00:00:00',
+				filename: 'test.csv',
+				ignoreCache: false,
+			},
+		});
+
+		fs.existsSync.mockReturnValue(true);
+		fs.statSync.mockReturnValue({ size: 0 });
+
+		const command = new GetBulkLogCommand([], {});
+		await expect(command.run()).rejects.toThrow(
+			'Cannot get logs more than 30 days old. Adjust your time range.',
+		);
+	});
+});
+
+describe('validateDateTimeRange', () => {
+	const testCases = [
+		{
+			startTime: '2025-03-09T12:00:00Z',
+			endTime: '2025-03-09T12:45:00Z',
+			error:
+				'Max duration between startTime and endTime should be 30 minutes. Current duration is 0 hours 45 minutes and 0 seconds.',
+		},
+		{
+			startTime: new Date().toISOString(),
+			endTime: new Date(new Date().getTime() + 45 * 60 * 1000).toISOString(),
+			error: 'endTime cannot be in the future. Provide a valid endTime.',
+		},
+		{
+			startTime: new Date(new Date().setUTCDate(new Date().getUTCDate() - 31)).toISOString(),
+			endTime: '2025-03-10T12:00:00Z',
+			error: 'Cannot get logs more than 30 days old. Adjust your time range.',
+		},
+		{
+			startTime: '2025-03-09T12:00:00Z',
+			endTime: '2025-03-09T12:00:00Z',
+			error: 'Minimum duration should be 1 minutes. Current duration is 0 minutes.',
+		},
+		{
+			startTime: '2025-03-09T12:30:00Z',
+			endTime: '2025-03-09T12:00:00Z',
+			error: 'endTime must be greater than startTime',
+		},
+		{
+			startTime: '2025-03-09T12:00:00Z',
+			endTime: '2025-03-09T12:20:00Z',
+			error: null,
+		},
+	];
+
+	test.each(testCases)(
+		'validates time range for startTime: $startTime and endTime: $endTime',
+		({ startTime, endTime, error }) => {
+			if (error) {
+				expect(() => validateDateTimeRange(startTime, endTime)).toThrow(error);
+			} else {
+				expect(() => validateDateTimeRange(startTime, endTime)).not.toThrow();
+			}
+		},
+	);
+});
+
+describe('parsePastDuration', () => {
+	const validDurations = [
+		['20m', 20 * 60 * 1000],
+		['20 m', 20 * 60 * 1000],
+		['20min', 20 * 60 * 1000],
+		['20 min', 20 * 60 * 1000],
+		['20mins', 20 * 60 * 1000],
+		['20 mins', 20 * 60 * 1000],
+		['20minute', 20 * 60 * 1000],
+		['20 minute', 20 * 60 * 1000],
+		['20minutes', 20 * 60 * 1000],
+		['20 minutes', 20 * 60 * 1000],
+	];
+
+	test.each(validDurations)(
+		'parses valid past duration "%s" correctly',
+		(pastDuration, expectedDurationInMs) => {
+			const durationInMs = parsePastDuration(pastDuration);
+			expect(durationInMs).toBe(expectedDurationInMs);
+		},
+	);
+
+	const invalidDurations = ['20h', '20 hours', '20s', '20 seconds'];
+
+	test.each(invalidDurations)(
+		'throws an error for invalid past duration format "%s"',
+		invalidPastDuration => {
+			expect(() => parsePastDuration(invalidPastDuration)).toThrow(
+				'Invalid format. Past time window should be in minutes, e.g., "20 mins", "15 minutes".',
+			);
 		},
 	);
 });

--- a/src/commands/api-mesh/__tests__/log-get-bulk.test.js
+++ b/src/commands/api-mesh/__tests__/log-get-bulk.test.js
@@ -304,6 +304,7 @@ describe('GetBulkLogCommand with --past and --from flags', () => {
 	beforeEach(() => {
 		now = new Date();
 		fromDate = new Date(now);
+		fromDate.setDate(fromDate.getDate() - 29); // Set fromDate to 29 days ago
 		parseSpy = jest.spyOn(GetBulkLogCommand.prototype, 'parse').mockResolvedValue({
 			flags: {
 				past: '20mins',

--- a/src/commands/api-mesh/log-get-bulk.js
+++ b/src/commands/api-mesh/log-get-bulk.js
@@ -59,7 +59,7 @@ class GetBulkLogCommand extends Command {
 			if (!dateTimeRegex.test(flags.startTime)) {
 				const correctedStartTime = suggestCorrectedDateFormat(flags.startTime);
 				if (!correctedStartTime) {
-					this.error('Found invalid date components for startTime. Check and correct the date.');
+					this.error('Invalid date components in startTime. Correct the date.');
 				} else {
 					this.error(
 						`Use the format YYYY-MM-DDTHH:MM:SSZ for startTime. Did you mean ${correctedStartTime}?`,
@@ -100,7 +100,7 @@ class GetBulkLogCommand extends Command {
 						convertedTime = await localToUTCTime(flags.from.toString());
 					} catch (error) {
 						this.error(
-							`Found invalid date components passed in --from. Check and correct the date.`,
+							`Invalid date components passed in --from. Correct the date.`,
 						);
 					}
 				}

--- a/src/commands/api-mesh/log-get-bulk.js
+++ b/src/commands/api-mesh/log-get-bulk.js
@@ -94,11 +94,14 @@ class GetBulkLogCommand extends Command {
 				let convertedTime;
 				const dateTimeRegex = /^\d{4}-\d{2}-\d{2}:\d{2}:\d{2}:\d{2}$/;
 				if (!dateTimeRegex.test(flags.from)) {
-					this.error('Found invalid date components passed in --from. Check and correct the date.');
+					this.error('Invalid format. Use the format YYYY-MM-DD:HH:MM:SS for --from.');
 				} else {
-					convertedTime = await localToUTCTime(flags.from.toString());
-					if (!convertedTime) {
-						this.error('Invalid format. Use the format YYYY-MM-DD:HH:MM:SS for --from.');
+					try {
+						convertedTime = await localToUTCTime(flags.from.toString());
+					} catch (error) {
+						this.error(
+							`Found invalid date components passed in --from. Check and correct the date.`,
+						);
 					}
 				}
 				// add the past window to the converted time to get the end time to fetch logs from the past

--- a/src/commands/api-mesh/log-get-bulk.js
+++ b/src/commands/api-mesh/log-get-bulk.js
@@ -21,7 +21,6 @@ const {
 
 require('dotenv').config();
 
-
 class GetBulkLogCommand extends Command {
 	static flags = {
 		ignoreCache: ignoreCacheFlag,
@@ -67,7 +66,6 @@ class GetBulkLogCommand extends Command {
 					);
 				}
 				return;
-
 			}
 
 			// Validate user provided endTime format
@@ -97,12 +95,10 @@ class GetBulkLogCommand extends Command {
 				const dateTimeRegex = /^\d{4}-\d{2}-\d{2}:\d{2}:\d{2}:\d{2}$/;
 				if (!dateTimeRegex.test(flags.from)) {
 					this.error('Found invalid date components passed in --from. Check and correct the date.');
-
 				} else {
 					convertedTime = await localToUTCTime(flags.from.toString());
 					if (!convertedTime) {
 						this.error('Invalid format. Use the format YYYY-MM-DD:HH:MM:SS for --from.');
-
 					}
 				}
 				// add the past window to the converted time to get the end time to fetch logs from the past
@@ -119,12 +115,13 @@ class GetBulkLogCommand extends Command {
 			// Properly format startTime and endTime strings before handing it over to SMS i.e remove the milliseconds
 			formattedStartTime = validateDateTimeFormat(calculatedStartTime);
 			formattedEndTime = validateDateTimeFormat(calculatedEndTime);
-		} else if (flags.startTime && !flags.endTime || !flags.startTime && flags.endTime) {
-
+		} else if ((flags.startTime && !flags.endTime) || (!flags.startTime && flags.endTime)) {
 			this.error('Provide both startTime and endTime.');
 			return;
 		} else {
-			this.error('Missing required flags. Provide at least one flag --startTime, --endTime, or --past --from or  type `mesh log:get-bulk --help` for more information.');
+			this.error(
+				'Missing required flags. Provide at least one flag --startTime, --endTime, or --past --from or  type `mesh log:get-bulk --help` for more information.',
+			);
 			return;
 		}
 

--- a/src/commands/api-mesh/log-get-bulk.js
+++ b/src/commands/api-mesh/log-get-bulk.js
@@ -99,9 +99,7 @@ class GetBulkLogCommand extends Command {
 					try {
 						convertedTime = await localToUTCTime(flags.from.toString());
 					} catch (error) {
-						this.error(
-							`Invalid date components passed in --from. Correct the date.`,
-						);
+						this.error(`Invalid date components passed in --from. Correct the date.`);
 					}
 				}
 				// add the past window to the converted time to get the end time to fetch logs from the past

--- a/src/utils.js
+++ b/src/utils.js
@@ -85,7 +85,8 @@ const pastFlag = Flags.string({
 });
 
 const fromFlag = Flags.string({
-	description: 'From time in DD-MM-YYYY:HH:MM:SS format to fetch logs from the past. Used as the starting time for the past time duration.',
+	description:
+		'From time in DD-MM-YYYY:HH:MM:SS format to fetch logs from the past. Used as the starting time for the past time duration.',
 });
 
 const logFilenameFlag = Flags.string({
@@ -606,7 +607,6 @@ function suggestCorrectedDateFormat(inputDate) {
 	return correctedDate;
 }
 
-
 /**
  * Parses a duration string representing a past time window and converts it to milliseconds.
  *
@@ -619,21 +619,23 @@ function parsePastDuration(pastTimeWindow) {
 	const match = pastTimeWindow.match(pastDurationRegex);
 
 	if (!match) {
-		throw new Error('Invalid format. Past time window should be in minutes, e.g., "20 mins", "15 minutes".');
+		throw new Error(
+			'Invalid format. Past time window should be in minutes, e.g., "20 mins", "15 minutes".',
+		);
 	}
 
-	// Convert the matched duration to milliseconds 
+	// Convert the matched duration to milliseconds
 	const durationInMs = ms(pastTimeWindow);
 
 	return durationInMs;
 }
 
 /**
-	 * Validates the provided startTime and endTime flags.
-	 *
-	 * @param {string} startTime - The start time in the format YYYY-MM-DDTHH:MM:SSZ
-	 * @param {string} endTime - The end time in the format YYYY-MM-DDTHH:MM:SSZ
-	 */
+ * Validates the provided startTime and endTime flags.
+ *
+ * @param {string} startTime - The start time in the format YYYY-MM-DDTHH:MM:SSZ
+ * @param {string} endTime - The end time in the format YYYY-MM-DDTHH:MM:SSZ
+ */
 function validateDateTimeRange(startTime, endTime) {
 	// Convert formatted times to Date objects for comparison
 	const start = new Date(startTime);
@@ -648,7 +650,6 @@ function validateDateTimeRange(startTime, endTime) {
 	// Validate that logs from beyond 30 days from today are not available
 	if (start < thirtyDaysAgo || end < thirtyDaysAgo) {
 		throw new Error('Cannot get logs more than 30 days old. Adjust your time range.');
-		return;
 	}
 
 	// Truncate milliseconds to ensure comparison is only done up to seconds
@@ -658,18 +659,15 @@ function validateDateTimeRange(startTime, endTime) {
 	// Validate startTime < endTime
 	if (start > end) {
 		throw new Error('endTime must be greater than startTime');
-		return;
 	}
 
 	// Validate that endTime is not greater than the current time (now)
 	if (end > now) {
 		throw new Error('endTime cannot be in the future. Provide a valid endTime.');
-		return;
 	}
 
 	if (start.getTime() === end.getTime()) {
 		throw new Error('Minimum duration should be 1 minutes. Current duration is 0 minutes.');
-		return;
 	}
 
 	// Check if the duration between start and end times is greater than 30 minutes (1800 seconds)
@@ -681,14 +679,14 @@ function validateDateTimeRange(startTime, endTime) {
 		const seconds = timeDifferenceInSeconds % 60; // Seconds calculation
 
 		throw new Error(
-			`Max duration between startTime and endTime should be 30 minutes. Current duration is ${hours} hour${hours !== 1 ? 's' : ''
-			} ${minutes} minute${minutes !== 1 ? 's' : ''} and ${seconds} second${seconds !== 1 ? 's' : ''
+			`Max duration between startTime and endTime should be 30 minutes. Current duration is ${hours} hour${
+				hours !== 1 ? 's' : ''
+			} ${minutes} minute${minutes !== 1 ? 's' : ''} and ${seconds} second${
+				seconds !== 1 ? 's' : ''
 			}.`,
 		);
-		return;
 	}
 }
-
 
 /**
  * Format and validate a given date string
@@ -696,7 +694,6 @@ function validateDateTimeRange(startTime, endTime) {
  * @returns {string|null} The formatted and validated date string or null if invalid
  */
 function validateDateTimeFormat(time) {
-
 	// Regular expression to validate the input date format YYYY-MM-DDTHH:MM:SSZ
 	const dateTimeRegex = /^(?:(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T(0[0-9]|1[0-9]|2[0-3]):([0-5]\d):([0-5]\d)Z)$/;
 
@@ -718,25 +715,26 @@ function validateDateTimeFormat(time) {
 /**
  * Convert a given local time string to UTC time string
  * @param {string} timeString - The time string in the format YYYY-MM-DD:Period:HH:MM:SS
- * @returns {string|null} The UTC time in the format YYYY-MM-DDTHH:mm:ss[Z] 
+ * @returns {string|null} The UTC time in the format YYYY-MM-DDTHH:mm:ss[Z]
  */
 async function localToUTCTime(timeString) {
-	// Split the input time string into components 
+	// Split the input time string into components
 	let [date, hour, minute, second] = timeString.split(':');
-	// Create a properly formatted date-time string 
+	// Create a properly formatted date-time string
 	const formattedTimeString = `${date}T${hour}:${minute}:${second}`;
 	try {
-		//Get the local timezone 
+		//Get the local timezone
 		const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-		console.log(`Local timezone: ${timeZone}`);
-		// Create a Date object from the formatted time string 
+
+		// Create a Date object from the formatted time string
 		const localTime = new Date(formattedTimeString);
-		// Convert to UTC 
+
+		// Convert to UTC
 		const utcTime = new Date(localTime.toUTCString('en-US', { timeZone: timeZone }));
+
 		// Return the UTC time in ISO format without milliseconds
 		return utcTime.toISOString().replace(/\.\d{3}Z$/, 'Z');
-	}
-	catch (error) {
+	} catch (error) {
 		logger.error(`Error: ${error.message}`);
 		throw error;
 	}

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,7 +91,7 @@ const pastFlag = Flags.string({
 });
 
 const fromFlag = Flags.string({
-	description: `The from time in DD-MM-YYYY:HH:MM:SS format based on your system's time zone. It is used to fetch logs from the past and is the starting time for the past time duration.`,
+	description: `The from time in YYYY-MM-DD:HH:MM:SS format based on your system's time zone. It is used to fetch logs from the past and is the starting time for the past time duration.`,
 });
 
 const logFilenameFlag = Flags.string({

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,7 @@ const { readFile } = require('fs/promises');
 const { interpolateMesh } = require('./helpers');
 const dotenv = require('dotenv');
 const YAML = require('yaml');
+const ms = require('ms');
 const parseEnv = require('envsub/js/envsub-parser');
 const os = require('os');
 const chalk = require('chalk');
@@ -73,12 +74,18 @@ const fileNameFlag = Flags.string({
 
 const startTimeFlag = Flags.string({
 	description: 'Start time for the logs in UTC',
-	required: true,
 });
 
 const endTimeFlag = Flags.string({
 	description: 'End time for the logs in UTC',
-	required: true,
+});
+
+const pastFlag = Flags.string({
+	description: 'Past time window in mins',
+});
+
+const fromFlag = Flags.string({
+	description: 'From time in DD-MM-YYYY:HH:MM:SS format to fetch logs from the past. Used as the starting time for the past time duration.',
 });
 
 const logFilenameFlag = Flags.string({
@@ -599,6 +606,142 @@ function suggestCorrectedDateFormat(inputDate) {
 	return correctedDate;
 }
 
+
+/**
+ * Parses a duration string representing a past time window and converts it to milliseconds.
+ *
+ * @param {string} pastTimeWindow - The past time duration to parse, e.g., "20 mins", "15 minutes".
+ * @returns {number} The duration in milliseconds.
+ */
+function parsePastDuration(pastTimeWindow) {
+	// Regular expression to match various formats of minute abbreviations
+	const pastDurationRegex = /^(\d+)\s*(m|mins?|minutes?)$/i;
+	const match = pastTimeWindow.match(pastDurationRegex);
+
+	if (!match) {
+		throw new Error('Invalid format. Past time window should be in minutes, e.g., "20 mins", "15 minutes".');
+	}
+
+	// Convert the matched duration to milliseconds 
+	const durationInMs = ms(pastTimeWindow);
+
+	return durationInMs;
+}
+
+/**
+	 * Validates the provided startTime and endTime flags.
+	 *
+	 * @param {string} startTime - The start time in the format YYYY-MM-DDTHH:MM:SSZ
+	 * @param {string} endTime - The end time in the format YYYY-MM-DDTHH:MM:SSZ
+	 */
+function validateDateTimeRange(startTime, endTime) {
+	// Convert formatted times to Date objects for comparison
+	const start = new Date(startTime);
+	const end = new Date(endTime);
+	const now = new Date(); // Current time
+
+	// Get the current date and calculate the date 30 days ago, both in UTC
+	const today = new Date();
+	const thirtyDaysAgo = new Date(today);
+	thirtyDaysAgo.setUTCDate(today.getUTCDate() - 30);
+
+	// Validate that logs from beyond 30 days from today are not available
+	if (start < thirtyDaysAgo || end < thirtyDaysAgo) {
+		throw new Error('Cannot get logs more than 30 days old. Adjust your time range.');
+		return;
+	}
+
+	// Truncate milliseconds to ensure comparison is only done up to seconds
+	start.setMilliseconds(0);
+	end.setMilliseconds(0);
+
+	// Validate startTime < endTime
+	if (start > end) {
+		throw new Error('endTime must be greater than startTime');
+		return;
+	}
+
+	// Validate that endTime is not greater than the current time (now)
+	if (end > now) {
+		throw new Error('endTime cannot be in the future. Provide a valid endTime.');
+		return;
+	}
+
+	if (start.getTime() === end.getTime()) {
+		throw new Error('Minimum duration should be 1 minutes. Current duration is 0 minutes.');
+		return;
+	}
+
+	// Check if the duration between start and end times is greater than 30 minutes (1800 seconds)
+	const timeDifferenceInSeconds = (end.getTime() - start.getTime()) / 1000;
+
+	if (timeDifferenceInSeconds > 1800) {
+		const hours = Math.floor(timeDifferenceInSeconds / 3600); // Hours calculation
+		const minutes = Math.floor((timeDifferenceInSeconds % 3600) / 60); // Minutes calculation
+		const seconds = timeDifferenceInSeconds % 60; // Seconds calculation
+
+		throw new Error(
+			`Max duration between startTime and endTime should be 30 minutes. Current duration is ${hours} hour${hours !== 1 ? 's' : ''
+			} ${minutes} minute${minutes !== 1 ? 's' : ''} and ${seconds} second${seconds !== 1 ? 's' : ''
+			}.`,
+		);
+		return;
+	}
+}
+
+
+/**
+ * Format and validate a given date string
+ * @param {string} time - The time string in the format YYYY-MM-DDTHH:MM:SSZ
+ * @returns {string|null} The formatted and validated date string or null if invalid
+ */
+function validateDateTimeFormat(time) {
+
+	// Regular expression to validate the input date format YYYY-MM-DDTHH:MM:SSZ
+	const dateTimeRegex = /^(?:(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T(0[0-9]|1[0-9]|2[0-3]):([0-5]\d):([0-5]\d)Z)$/;
+
+	// Convert the Date object to ISO string and remove milliseconds
+	let timeString = time.toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+	// Validate the formatted time string against the regex
+	if (!dateTimeRegex.test(timeString)) {
+		const correctedDate = suggestCorrectedDateFormat(timeString);
+		if (!correctedDate) {
+			throw Error(`Found invalid date components for ${timeString}. Check and correct the date.`);
+		}
+	}
+
+	// Return the formatted time string without dashes, colons, and 'Z'
+	return timeString.replace(/-|:|Z/g, '').replace('T', 'T');
+}
+
+/**
+ * Convert a given local time string to UTC time string
+ * @param {string} timeString - The time string in the format YYYY-MM-DD:Period:HH:MM:SS
+ * @returns {string|null} The UTC time in the format YYYY-MM-DDTHH:mm:ss[Z] 
+ */
+async function localToUTCTime(timeString) {
+	// Split the input time string into components 
+	let [date, hour, minute, second] = timeString.split(':');
+	// Create a properly formatted date-time string 
+	const formattedTimeString = `${date}T${hour}:${minute}:${second}`;
+	try {
+		//Get the local timezone 
+		const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+		console.log(`Local timezone: ${timeZone}`);
+		// Create a Date object from the formatted time string 
+		const localTime = new Date(formattedTimeString);
+		// Convert to UTC 
+		const utcTime = new Date(localTime.toUTCString('en-US', { timeZone: timeZone }));
+		// Return the UTC time in ISO format without milliseconds
+		return utcTime.toISOString().replace(/\.\d{3}Z$/, 'Z');
+	}
+	catch (error) {
+		logger.error(`Error: ${error.message}`);
+		throw error;
+	}
+}
+
 module.exports = {
 	ignoreCacheFlag,
 	autoConfirmActionFlag,
@@ -620,5 +763,11 @@ module.exports = {
 	startTimeFlag,
 	endTimeFlag,
 	logFilenameFlag,
+	pastFlag,
+	fromFlag,
 	suggestCorrectedDateFormat,
+	parsePastDuration,
+	validateDateTimeRange,
+	validateDateTimeFormat,
+	localToUTCTime,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -92,7 +92,7 @@ const pastFlag = Flags.string({
 
 const fromFlag = Flags.string({
 	description:
-		'From time in DD-MM-YYYY:HH:MM:SS format to fetch logs from the past. Used as the starting time for the past time duration.',
+		'The from time in DD-MM-YYYY:HH:MM:SS format based on your system's time zone. It is used to fetch logs from the past and is the starting time for the past time duration.',
 });
 
 const logFilenameFlag = Flags.string({
@@ -626,7 +626,7 @@ function parsePastDuration(pastTimeWindow) {
 
 	if (!match) {
 		throw new Error(
-			'Invalid format. Past time window should be in minutes, e.g., "20 mins", "15 minutes".',
+			'Invalid format. The past time window should be in minutes, for example, "20 mins", "15 minutes".',
 		);
 	}
 
@@ -673,7 +673,7 @@ function validateDateTimeRange(startTime, endTime) {
 	}
 
 	if (start.getTime() === end.getTime()) {
-		throw new Error('Minimum duration should be 1 minutes. Current duration is 0 minutes.');
+		throw new Error('The minimum duration is 1 minutes. The current duration is 0 minutes.');
 	}
 
 	// Check if the duration between start and end times is greater than 30 minutes (1800 seconds)
@@ -685,7 +685,7 @@ function validateDateTimeRange(startTime, endTime) {
 		const seconds = timeDifferenceInSeconds % 60; // Seconds calculation
 
 		throw new Error(
-			`Max duration between startTime and endTime should be 30 minutes. Current duration is ${hours} hour${
+			`The maximum duration between startTime and endTime is 30 minutes. The current duration is ${hours} hour${
 				hours !== 1 ? 's' : ''
 			} ${minutes} minute${minutes !== 1 ? 's' : ''} and ${seconds} second${
 				seconds !== 1 ? 's' : ''
@@ -710,7 +710,7 @@ function validateDateTimeFormat(time) {
 	if (!dateTimeRegex.test(timeString)) {
 		const correctedDate = suggestCorrectedDateFormat(timeString);
 		if (!correctedDate) {
-			throw Error(`Found invalid date components for ${timeString}. Check and correct the date.`);
+			throw Error(`Invalid date components in ${timeString}. Confirm the date information is correct.`);
 		}
 	}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,8 +91,7 @@ const pastFlag = Flags.string({
 });
 
 const fromFlag = Flags.string({
-	description:
-		'The from time in DD-MM-YYYY:HH:MM:SS format based on your system's time zone. It is used to fetch logs from the past and is the starting time for the past time duration.',
+	description: `The from time in DD-MM-YYYY:HH:MM:SS format based on your system's time zone. It is used to fetch logs from the past and is the starting time for the past time duration.`,
 });
 
 const logFilenameFlag = Flags.string({
@@ -710,7 +709,9 @@ function validateDateTimeFormat(time) {
 	if (!dateTimeRegex.test(timeString)) {
 		const correctedDate = suggestCorrectedDateFormat(timeString);
 		if (!correctedDate) {
-			throw Error(`Invalid date components in ${timeString}. Confirm the date information is correct.`);
+			throw Error(
+				`Invalid date components in ${timeString}. Confirm the date information is correct.`,
+			);
 		}
 	}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -720,7 +720,7 @@ function validateDateTimeFormat(time) {
 
 /**
  * Convert a given local time string to UTC time string
- * @param {string} timeString - The time string in the format YYYY-MM-DD:Period:HH:MM:SS
+ * @param {string} timeString - The time string in the format YYYY-MM-DD:HH:MM:SS
  * @returns {string|null} The UTC time in the format YYYY-MM-DDTHH:mm:ss[Z]
  */
 async function localToUTCTime(timeString) {
@@ -730,6 +730,8 @@ async function localToUTCTime(timeString) {
 	const formattedTimeString = `${date}T${hour}:${minute}:${second}`;
 	try {
 		//Get the local timezone
+		// takes the timezone where the javascript runtime is running
+		// reference https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions#browser_compatibility:~:text=The%20value%20provided%20for%20this%20property%20in%20the%20options%20argument%2C%20with%20default%20filled%20in%20as%20needed.%20It%20is%20an%20IANA%20time%20zone%20name.%20The%20default%20is%20the%20runtime%27s%20default%20time%20zone.
 		const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 		// Create a Date object from the formatted time string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR closes - https://jira.corp.adobe.com/browse/CEXT-4219

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Current log-get-bulk command accepts startTime and endTime in UTC format to fetch logs for 30 mins time window
`aio api-mesh log-get-bulk -- startTime YYYY-MM-DDTHH: MM: SSZ -- endTime YYYY-MM-DDTHH: MM: SSZ -- filename mesh_logs. csv`

It is bit inconvenient for the end user to give time in this particular format YYYY-MM-DDTHH: MM:SSZ.

Rather user should be able to give -- past 30 instead of – startTime YYYY-MM-DDTHH: MM:SSZ – endTime YYYY-MM-
DDTHH: MM:SSZ flag, to fetch the logs without needing to convert the time in the desired format.

<!--- Why is this change required? What problem does it solve? -->
Two cases need to be considered with the adding of the – past flag -

1. User requests log in for any time period less then 30 mins from now

- Calculate the startTime based on the current time which will serve as endTime, and use exisiting logic to fetch the logs.
- aio api-mesh log-get-bulk -- past 30mins -- filename logs.csv

2. User requests logs for any time period but less than 30 mins in any arbitrary time frame in the past the 30 days.

- Introduced `--from flag` - the time from which the `–past` time window needs to be calculated

- aio api-mesh log-get-bulk -- past 30mins -- from YYYY-MM-DD:HH:MM:SS -- filename logs.csv
- Convert the local time to UTC and then use existing logic to fetch logs, the decided format for –from time
 is YYYY-MM-DD:HH:MM:SS.

## How Has This Been Tested?
Addition of the above flags are additive and all the existing logic with --startTime and --endTime should work as is 
- Ran unit tests locally all passed

Tested scenarios for `--past` flag - 
1. if no logs found in provided --past window
<img width="431" alt="image" src="https://github.com/user-attachments/assets/1c6cacb6-a961-4e6a-9ca6-99b368128182" />

2. should download logs if found in given window 
<img width="432" alt="image" src="https://github.com/user-attachments/assets/1da07595-639e-42e4-852a-72dafa5a008d" />
TimeStamps should match from `aio api-mesh log-list`
<img width="752" alt="image" src="https://github.com/user-attachments/assets/f92e99b2-78ad-4d5a-82bc-4734e83a21f4" />

3. Invalid `--past` duration format (e.g., `20hour`, `20s`)
<img width="428" alt="image" src="https://github.com/user-attachments/assets/aafde1d9-a4d8-4b7d-ba4f-c5faaa36a850" />

4. Accepted valid `--past` durations abbreviations
<img width="443" alt="image" src="https://github.com/user-attachments/assets/3699a194-5f35-452c-b787-fafec4964fb5" />
<img width="451" alt="image" src="https://github.com/user-attachments/assets/47fdc034-247c-45ab-b0cd-e4da9dcf4256" />
  

Tested scenarios for `--from` flag - 
1. should download logs if found in given time window
<img width="489" alt="image" src="https://github.com/user-attachments/assets/262b7217-5a2b-4348-8da5-1454cd38d729" />

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
