### PR TITLE
Bugfix/cext 4376 fix run command resolver resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "5.2.1.beta.0",
+	"version": "5.2.1-beta",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "5.2.0",
+	"version": "5.2.1.beta.0",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/commands/api-mesh/run.js
+++ b/src/commands/api-mesh/run.js
@@ -228,7 +228,7 @@ class RunCommand extends Command {
 		}
 		// Move built tenant files if exists
 		if (fs.existsSync('mesh-artifact/tenantFiles')) {
-			// Tenant files included alongside the bundle for dynamic references
+			// Tenant files included in the bundle for runtime/dynamic imports
 			fs.cpSync('mesh-artifact/tenantFiles', '.mesh/tenantFiles', { recursive: true });
 			fs.renameSync('mesh-artifact/tenantFiles', 'tenantFiles');
 		}
@@ -238,8 +238,9 @@ class RunCommand extends Command {
 		if (fs.existsSync(`${__dirname}/../../../.mesh`)) {
 			fs.rmSync(`${__dirname}/../../../.mesh`, { recursive: true });
 		}
+		// At this time the bundle and build files must be copied out to the plugin directory
 		fs.cpSync('.mesh', `${__dirname}/../../../.mesh`, { recursive: true });
-		// Tenant files included in the bundle for static imports
+		// Tenant files used at build time
 		fs.cpSync('tenantFiles', `${__dirname}/../../../tenantFiles`, { recursive: true });
 	}
 }

--- a/src/commands/api-mesh/run.js
+++ b/src/commands/api-mesh/run.js
@@ -228,6 +228,7 @@ class RunCommand extends Command {
 		}
 		// Move built tenant files if exists
 		if (fs.existsSync('mesh-artifact/tenantFiles')) {
+			// Tenant files included alongside the bundle for dynamic references
 			fs.cpSync('mesh-artifact/tenantFiles', '.mesh/tenantFiles', { recursive: true });
 			fs.renameSync('mesh-artifact/tenantFiles', 'tenantFiles');
 		}
@@ -238,6 +239,8 @@ class RunCommand extends Command {
 			fs.rmSync(`${__dirname}/../../../.mesh`, { recursive: true });
 		}
 		fs.cpSync('.mesh', `${__dirname}/../../../.mesh`, { recursive: true });
+		// Tenant files included in the bundle for static imports
+		fs.cpSync('tenantFiles', `${__dirname}/../../../tenantFiles`, { recursive: true });
 	}
 }
 


### PR DESCRIPTION
## Description

This fix includes the missing tenant files directory required for build time resolution of additional resolvers.

## Related Issue

CEXT-4376

## Motivation and Context

The run command has issue resolving additional resolvers when running local mesh in workerd runtime. Given the nuance of wrangler assuming the cwd based on the templated entry point, files were copied relative to this entry point to build/run. 

## How Has This Been Tested?

- Linked plugin
- Init new project with `aio api-mesh init`
- Update mesh config. Example:
```
// mesh.json
{
	"meshConfig": {
		"sources": [
			{
				"name": "AdobeCommerceAPI",
				"handler": {
					"graphql": {
						"endpoint": "{{env.COMMERCE_ENDPOINT}}"
					}
				}
			}
		],
		"additionalTypeDefs": [
			"extend type Query { createOrder: String }"
		],
		"additionalResolvers": [
			"./resolver.js"
		]
	}
}
```
```
// resolver.js
async function createOrder() {
	return "Accepted";
}

module.exports = {
	Query: {
		createOrder
	}
};
```
- Run mesh locally `aio run mesh.json`

## Screenshots (if appropriate):

Before:
![image](https://github.com/user-attachments/assets/b59efe57-5895-444a-a61e-4135f72c154c)

After:
![image](https://github.com/user-attachments/assets/d366664e-126d-4c1f-a517-2b84ccfb04c2)
![image](https://github.com/user-attachments/assets/abc4bf1b-cca7-4f11-a614-b3b1ea67d73c)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
