### PR TITLE
feat(metadata): initialize dotenv and include API mesh environment variables

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,7 @@
 const { getCliEnv } = require('@adobe/aio-lib-env');
+const dotenv = require('dotenv');
 
+dotenv.config();
 const clientEnv = getCliEnv();
 
 const StageConstants = {
@@ -24,4 +26,16 @@ const ProdConstants = {
 };
 
 const envConstants = clientEnv === 'stage' ? StageConstants : ProdConstants;
-module.exports = { ...envConstants };
+
+// Export environment variables/constants
+module.exports = {
+	DEV_CONSOLE_BASE_URL: process.env.DEV_CONSOLE_BASE_URL || envConstants.DEV_CONSOLE_BASE_URL,
+	DEV_CONSOLE_API_KEY: process.env.DEV_CONSOLE_API_KEY || envConstants.DEV_CONSOLE_API_KEY,
+	DEV_CONSOLE_TRANSPORTER_API_KEY:
+		process.env.DEV_CONSOLE_TRANSPORTER_API_KEY || envConstants.DEV_CONSOLE_TRANSPORTER_API_KEY,
+	AIO_CLI_API_KEY: process.env.AIO_CLI_API_KEY || envConstants.AIO_CLI_API_KEY,
+	SMS_BASE_URL: process.env.SMS_BASE_URL || envConstants.SMS_BASE_URL,
+	MESH_BASE_URL: process.env.MESH_BASE_URL || envConstants.MESH_BASE_URL,
+	MESH_SANDBOX_BASE_URL: process.env.MESH_SANDBOX_BASE_URL || envConstants.MESH_SANDBOX_BASE_URL,
+	SMS_API_KEY: process.env.SMS_API_KEY || envConstants.SMS_API_KEY,
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,6 +24,7 @@ const { stdout, stderr } = require('process');
 const jsmin = require('jsmin').jsmin;
 const { resolve: resolveAbsolutePath } = require('path');
 const { compareVersions } = require('compare-versions');
+const dotenv = require('dotenv');
 
 const logger = require('../src/classes/logger');
 const { UUID } = require('./classes/UUID');
@@ -449,6 +450,7 @@ function initRequestId() {
  */
 function initMetadata(config) {
 	try {
+		dotenv.config();
 		const { version, plugins, userAgent, platform, arch } = config;
 		const currentIntalledVersion = getCurrentInstalledPluginVersion(plugins);
 
@@ -459,6 +461,13 @@ function initMetadata(config) {
 			'x-aio-cli-arch': arch,
 			'x-aio-cli-plugin-api-mesh-version': currentIntalledVersion,
 		};
+
+		// Include any api mesh prefixed environment variables
+		Object.entries(process.env).forEach(([key, value]) => {
+			if (key.startsWith('x-aio-cli-plugin-api-mesh')) {
+				metadataHeaders[key] = value;
+			}
+		});
 
 		global.metadataHeaders = metadataHeaders;
 	} catch (error) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -24,7 +24,6 @@ const { stdout, stderr } = require('process');
 const jsmin = require('jsmin').jsmin;
 const { resolve: resolveAbsolutePath } = require('path');
 const { compareVersions } = require('compare-versions');
-const dotenv = require('dotenv');
 
 const logger = require('../src/classes/logger');
 const { UUID } = require('./classes/UUID');
@@ -450,30 +449,16 @@ function initRequestId() {
  */
 function initMetadata(config) {
 	try {
-		dotenv.config();
 		const { version, plugins, userAgent, platform, arch } = config;
 		const currentIntalledVersion = getCurrentInstalledPluginVersion(plugins);
 
-		const metadataHeaders = {
+		global.metadataHeaders = {
 			'x-aio-cli-version': version,
 			'x-aio-cli-user-agent': userAgent,
 			'x-aio-cli-platform': platform,
 			'x-aio-cli-arch': arch,
 			'x-aio-cli-plugin-api-mesh-version': currentIntalledVersion,
 		};
-
-		// Include any api mesh prefixed environment variables
-		Object.entries(process.env).forEach(([key, value]) => {
-			if (key.startsWith('AIO_CLI_PLUGIN_API_MESH')) {
-				// Reformat env var to header
-				const header = `x-${key.toLowerCase().replaceAll('_', '-')}`;
-				metadataHeaders[header] = value;
-			}
-		});
-
-		console.log(metadataHeaders);
-
-		global.metadataHeaders = metadataHeaders;
 	} catch (error) {
 		logger.error('Unable to initialize metadata headers');
 		logger.error(error.message);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -464,9 +464,9 @@ function initMetadata(config) {
 
 		// Include any api mesh prefixed environment variables
 		Object.entries(process.env).forEach(([key, value]) => {
-			if (key.startsWith('X_AIO_CLI_PLUGIN_API_MESH')) {
+			if (key.startsWith('AIO_CLI_PLUGIN_API_MESH')) {
 				// Reformat env var to header
-				const header = key.toLowerCase().replaceAll('_', '-');
+				const header = `x-${key.toLowerCase().replaceAll('_', '-')}`;
 				metadataHeaders[header] = value;
 			}
 		});

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -464,8 +464,10 @@ function initMetadata(config) {
 
 		// Include any api mesh prefixed environment variables
 		Object.entries(process.env).forEach(([key, value]) => {
-			if (key.startsWith('x-aio-cli-plugin-api-mesh')) {
-				metadataHeaders[key] = value;
+			if (key.startsWith('X_AIO_CLI_PLUGIN_API_MESH')) {
+				// Reformat env var to header
+				const header = key.toLowerCase().replace('_', '-');
+				metadataHeaders[header] = value;
 			}
 		});
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -466,10 +466,12 @@ function initMetadata(config) {
 		Object.entries(process.env).forEach(([key, value]) => {
 			if (key.startsWith('X_AIO_CLI_PLUGIN_API_MESH')) {
 				// Reformat env var to header
-				const header = key.toLowerCase().replace('_', '-');
+				const header = key.toLowerCase().replaceAll('_', '-');
 				metadataHeaders[header] = value;
 			}
 		});
+
+		console.log(metadataHeaders);
 
 		global.metadataHeaders = metadataHeaders;
 	} catch (error) {


### PR DESCRIPTION
## Description

API Mesh CLI plugin has no way to include custom headers required to identify traffic in certain environments. Change to source values from environment variables and default to constants for an environment when not present.

## Related Issue

CEXT-4492

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
