### PR TITLE
fix(bigint-serialization): - Fixed OpenAPI source BigInt scalar serialization to JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 		"graphql": "^16.6.0",
 		"inquirer": "^8.2.4",
 		"jsmin": "1.0.1",
+		"json-bigint-patch": "^0.0.8",
 		"json-interpolate": "^1.0.3",
 		"lru-cache": "^7.14.1",
 		"node-clipboardy": "^1.0.3",
@@ -138,7 +139,9 @@
 	},
 	"oclif": {
 		"topics": {
-			"api-mesh": { "description": "Create, run, test, and deploy API Mesh"}
+			"api-mesh": {
+				"description": "Create, run, test, and deploy API Mesh"
+			}
 		},
 		"commands": "./src/commands",
 		"bin": "aio",

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,3 +1,5 @@
+import 'json-bigint-patch';
+
 import { ServedTier, addServedHeader } from './served';
 import { buildServer } from './server';
 import { bindedlogger as logger } from './utils/logger';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7597,7 +7597,7 @@ jsmin@1.0.1:
   resolved "https://registry.yarnpkg.com/jsmin/-/jsmin-1.0.1.tgz#e7bd0dcd6496c3bf4863235bf461a3d98aa3b98c"
   integrity sha512-OPuL5X/bFKgVdMvEIX3hnpx3jbVpFCrEM8pKPXjFkZUqg521r41ijdyTz7vACOhW6o1neVlcLyd+wkbK5fNHRg==
 
-json-bigint-patch@0.0.8:
+json-bigint-patch@0.0.8, json-bigint-patch@^0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/json-bigint-patch/-/json-bigint-patch-0.0.8.tgz#45d954da1f21c6d4f3ae9ef64c9ac227cd0ab0fe"
   integrity sha512-xa0LTQsyaq8awYyZyuUsporWisZFiyqzxGW8CKM3t7oouf0GFAKYJnqAm6e9NLNBQOCtOLvy614DEiRX/rPbnA==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

OpenAPI sources generate BigInt scalars for Int64 format integers. Mesh fails to serialize this scalar to JSON. This change patches JSON parse to support BigInt.

## Related Issue

CEXT-4620

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Linked CLI plugin

## Screenshots (if appropriate):

Before
![image](https://github.com/user-attachments/assets/0757586f-e2cc-47cc-a15b-a3ade279ea65)

After
![image](https://github.com/user-attachments/assets/c874bbec-e159-4cee-96ca-c3bb999c2771)
![image](https://github.com/user-attachments/assets/9bb99ffa-850b-4f92-94d0-e1b6e7e71fb5)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
