### PR TITLE
Chore/local dev remote hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "5.3.3",
+	"version": "5.4.0-beta.0",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/__tests__/meshArtifact.test.js
+++ b/src/__tests__/meshArtifact.test.js
@@ -1,0 +1,144 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const fs = require('fs');
+const path = require('path');
+
+jest.mock('fs');
+jest.mock('path');
+jest.mock('../../src/classes/logger', () => ({
+	error: jest.fn(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	debug: jest.fn(),
+}));
+
+const {
+	isTypeScriptFile,
+	resolveComposerAsTypeScriptModule,
+	resolveComposerAsJavaScriptModule,
+	resolveComposerAsStaticImport,
+	resolveRelativeSources,
+	resolveOriginalSources,
+} = require('../meshArtifact');
+
+describe('meshArtifact', () => {
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('isTypeScriptFile', () => {
+		it('returns true for .ts files', () => {
+			path.extname.mockReturnValue('.ts');
+			expect(isTypeScriptFile('file.ts')).toBe(true);
+		});
+		it('returns true for .tsx files', () => {
+			path.extname.mockReturnValue('.tsx');
+			expect(isTypeScriptFile('file.tsx')).toBe(true);
+		});
+		it('returns false for .js files', () => {
+			path.extname.mockReturnValue('.js');
+			expect(isTypeScriptFile('file.js')).toBe(false);
+		});
+	});
+
+	describe('resolveComposerAsTypeScriptModule', () => {
+		it('replaces composer string with await import', () => {
+			const input = `"composer": "/path/to/file.js#fn"`;
+			const output = resolveComposerAsTypeScriptModule(input);
+			expect(output).toContain(`"module": await import("/path/to/file.js"), "fn": "fn"`);
+		});
+		it('does not replace composer string with https:// endpoint', () => {
+			const input = `"composer": "https://localhost:9999/file.js#fn"`;
+			const output = resolveComposerAsTypeScriptModule(input);
+			expect(output).toBe(input);
+		});
+	});
+
+	describe('resolveComposerAsJavaScriptModule', () => {
+		it('replaces composer string with __importStar(require(...))', () => {
+			const input = `"composer": "/path/to/file.js#fn"`;
+			const output = resolveComposerAsJavaScriptModule(input);
+			expect(output).toContain(`"module": __importStar(require("/path/to/file.js")), "fn": "fn"`);
+		});
+		it('does not replace composer string with https:// endpoint', () => {
+			const input = `"composer": "https://localhost:9999/file.js#fn"`;
+			const output = resolveComposerAsJavaScriptModule(input);
+			expect(output).toBe(input);
+		});
+	});
+
+	describe('resolveComposerAsStaticImport', () => {
+		it('uses TypeScript resolver for .ts files', () => {
+			path.extname.mockReturnValue('.ts');
+			const input = `"composer": "/path/to/file.ts#fn"`;
+			const output = resolveComposerAsStaticImport('file.ts', input);
+			expect(output).toContain('await import');
+		});
+		it('uses JavaScript resolver for .js files', () => {
+			path.extname.mockReturnValue('.js');
+			const input = `"composer": "/path/to/file.js#fn"`;
+			const output = resolveComposerAsStaticImport('file.js', input);
+			expect(output).toContain('__importStar(require');
+		});
+	});
+
+	describe('resolveRelativeSources', () => {
+		it('replaces ../tenantFiles with ./tenantFiles in mesh artifact', async () => {
+			const builtMeshTenantDir = '/mesh/tenant';
+			const builtMeshPath = '/mesh/tenant/index.js';
+			const artifactFilesPath = '/mesh/tenant/files.json';
+			path.join.mockImplementation((...args) => args.join('/'));
+			path.extname.mockReturnValue('.js');
+			fs.existsSync.mockImplementation(p => p === artifactFilesPath);
+			fs.readFileSync.mockReturnValue('require("../tenantFiles/some.js")');
+			fs.writeFileSync.mockImplementation(() => {});
+
+			await resolveRelativeSources(builtMeshTenantDir);
+
+			expect(fs.writeFileSync).toHaveBeenCalledWith(
+				builtMeshPath,
+				expect.stringContaining('./tenantFiles'),
+				'utf8',
+			);
+		});
+	});
+
+	describe('resolveOriginalSources', () => {
+		it('replaces materializedPath with absolute path if file exists', async () => {
+			const builtMeshTenantDir = '/mesh/tenant';
+			const builtMeshPath = '/mesh/tenant/index.js';
+			const artifactFilesPath = '/mesh/tenant/files.json';
+			path.join.mockImplementation((...args) => args.join('/'));
+			path.extname.mockReturnValue('.js');
+			fs.existsSync.mockImplementation(p => p === artifactFilesPath || p === '/abs/file.js');
+			fs.readFileSync.mockImplementation(p => {
+				if (p === artifactFilesPath) {
+					return JSON.stringify({
+						files: [{ path: '/abs/file.js', materializedPath: '/mat/file.js' }],
+					});
+				}
+				return 'require("/mat/file.js")';
+			});
+			fs.writeFileSync.mockImplementation(() => {});
+			path.resolve.mockImplementation(p => p);
+
+			await resolveOriginalSources(builtMeshTenantDir, {});
+
+			expect(fs.writeFileSync).toHaveBeenCalledWith(
+				builtMeshPath,
+				expect.stringContaining('/abs/file.js'),
+				'utf8',
+			);
+		});
+	});
+});

--- a/src/meshArtifact.js
+++ b/src/meshArtifact.js
@@ -45,7 +45,7 @@ function getBuiltMeshEntrypoint(builtMeshTenantDir) {
  */
 function resolveComposerAsTypeScriptModule(data) {
 	return data.replace(
-		/"composer":\s*"([^#]+)#([^"]+)"/,
+		/"composer":\s*"((?!https:\/\/)[^#]+)#([^"]+)"/,
 		`"module": await import("$1"), "fn": "$2"`,
 	);
 }
@@ -71,7 +71,7 @@ function resolveComposerAsTypeScriptModule(data) {
  */
 function resolveComposerAsJavaScriptModule(data) {
 	return data.replace(
-		/"composer":\s*"([^#]+)#([^"]+)"/,
+		/"composer":\s*"((?!https:\/\/)[^#]+)#([^"]+)"/,
 		`"module": __importStar(require("$1")), "fn": "$2"`,
 	);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Local dev does not support remote hooks. Adjusted artifact logic to ensure that remote hook composer interface is maintained.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

CEXT-4699

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Create mesh with both local and remote hooks
- Run mesh locally `aio api-mesh run mesh.json`
- Local hooks run without error
- Remote hooks invoked without error

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
