### PR TITLE
Added active flag in get command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/setup-node@v3
           with:
-            node-version: 20
+            node-version: 22
         - run: yarn global add @adobe/aio-cli
         - run: yarn install --frozen-lockfile
         - run: yarn run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/setup-node@v3
           with:
-            node-version: 18
+            node-version: 20
         - run: yarn global add @adobe/aio-cli
         - run: yarn install --frozen-lockfile
         - run: yarn run lint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adobe/aio-cli-plugin-api-mesh",
-	"version": "5.4.1",
+	"version": "5.5.0-beta.1",
 	"description": "Adobe I/O CLI plugin to develop and manage API mesh sources",
 	"keywords": [
 		"oclif-plugin"

--- a/src/commands/api-mesh/__tests__/get.test.js
+++ b/src/commands/api-mesh/__tests__/get.test.js
@@ -121,21 +121,13 @@ describe('get command tests', () => {
 
 	test('should fail if mesh is missing', async () => {
 		getMesh.mockResolvedValueOnce(null);
-		const runResult = GetCommand.run();
 
-		return runResult.catch(err => {
-			expect(err.message).toMatchInlineSnapshot(
-				`"Unable to get mesh config. No mesh found for Org(1234) -> Project(5678) -> Workspace(123456789). Check the details and try again."`,
-			);
-			expect(logSpy.mock.calls).toMatchInlineSnapshot(`[]`);
-			expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
-			[
-			  [
-			    "Unable to get mesh config. No mesh found for Org(1234) -> Project(5678) -> Workspace(123456789). Check the details and try again.",
-			  ],
-			]
-		`);
-		});
+		await GetCommand.run();
+
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+		expect(errorLogSpy.mock.calls[0][0]).toBe(
+			'Unable to get mesh config. No mesh found for Org(CODE1234@AdobeOrg) -> Project(5678) -> Workspace(123456789). Please check the details and try again.',
+		);
 	});
 
 	test('should fail if getMesh failed with MeshNotFound', async () => {
@@ -496,19 +488,18 @@ describe('get command tests', () => {
 			},
 		});
 
-		const runResult = GetCommand.run();
+		await GetCommand.run();
 
-		return runResult.catch(err => {
-			expect(err.message).toMatchInlineSnapshot(
-				`"Unable to get mesh config. No mesh found for Org(1234) -> Project(5678) -> Workspace(123456789). Please check the details and try again."`,
-			);
-			expect(getMesh).toHaveBeenCalledWith(
-				selectedOrg.code,
-				selectedProject.id,
-				selectedWorkspace.id,
-				selectedWorkspace.title,
-				true,
-			);
-		});
+		expect(logSpy.mock.calls).toMatchInlineSnapshot(`[]`);
+		expect(errorLogSpy.mock.calls[0][0]).toBe(
+			'Unable to get mesh config. No mesh found for Org(CODE1234@AdobeOrg) -> Project(5678) -> Workspace(123456789). Please check the details and try again.',
+		);
+		expect(getMesh).toHaveBeenCalledWith(
+			selectedOrg.code,
+			selectedProject.id,
+			selectedWorkspace.id,
+			selectedWorkspace.title,
+			true,
+		);
 	});
 });

--- a/src/commands/api-mesh/__tests__/get.test.js
+++ b/src/commands/api-mesh/__tests__/get.test.js
@@ -138,19 +138,19 @@ describe('get command tests', () => {
 		});
 	});
 
-	test('should fail if getMesh failed with MeshIdNotFound', async () => {
-		getMesh.mockRejectedValueOnce(new Error('MeshIdNotFound'));
+	test('should fail if getMesh failed with MeshNotFound', async () => {
+		getMesh.mockRejectedValueOnce(new Error('MeshNotFound'));
 		const runResult = GetCommand.run();
 
 		return runResult.catch(err => {
 			expect(err.message).toMatchInlineSnapshot(
-				`"Unable to get mesh ID. Check the details and try again. RequestId: dummy_request_id"`,
+				`"Unable to get mesh config. No mesh found for Org(1234) -> Project(5678) -> Workspace(123456789). Check the details and try again."`,
 			);
 			expect(logSpy.mock.calls).toMatchInlineSnapshot(`[]`);
 			expect(errorLogSpy.mock.calls).toMatchInlineSnapshot(`
 			[
 			  [
-			    "Unable to get mesh ID. Check the details and try again. RequestId: dummy_request_id",
+			    "Unable to get mesh config. No mesh found for Org(1234) -> Project(5678) -> Workspace(123456789). Check the details and try again.",
 			  ],
 			]
 		`);

--- a/src/commands/api-mesh/__tests__/get.test.js
+++ b/src/commands/api-mesh/__tests__/get.test.js
@@ -81,7 +81,7 @@ describe('get command tests', () => {
 
 	test('snapshot get command', () => {
 		expect(GetCommand.description).toMatchInlineSnapshot(
-			`"Get the config of a given mesh. Use --active flag to retrieve the last successfully deployed mesh config"`,
+			`"Get the config of a specified mesh. Use the --active flag to retrieve the last successfully deployed mesh config"`,
 		);
 		expect(GetCommand.args).toMatchInlineSnapshot(`
 		[
@@ -494,7 +494,7 @@ describe('get command tests', () => {
 
 		return runResult.catch(err => {
 			expect(err.message).toMatchInlineSnapshot(
-				`"No active deployment found for mesh dummy_meshId. Check the mesh ID and try again or try without --active flag to get the mesh config. RequestId: dummy_request_id"`,
+				`"No active deployment found for mesh dummy_meshId. Check the mesh ID and try again or try without the --active flag. RequestId: dummy_request_id"`,
 			);
 			expect(getMesh).toHaveBeenCalledWith(
 				selectedOrg.code,
@@ -524,7 +524,7 @@ describe('get command tests', () => {
 
 		return runResult.catch(err => {
 			expect(err.message).toMatchInlineSnapshot(
-				`"No active deployment found for mesh dummy_meshId. Check the mesh ID and try again or try without --active flag to get mesh config. RequestId: dummy_request_id"`,
+				`"No active deployment found for mesh dummy_meshId. Check the mesh ID and try again or try without the --active flag. RequestId: dummy_request_id"`,
 			);
 			expect(getMesh).toHaveBeenCalledWith(
 				selectedOrg.code,

--- a/src/commands/api-mesh/get.js
+++ b/src/commands/api-mesh/get.js
@@ -72,9 +72,10 @@ class GetCommand extends Command {
 				);
 			}
 		} catch (error) {
-			if (error.message === 'MeshIdNotFound') {
+			if (error.message === 'MeshNotFound') {
 				this.error(
-					`Unable to get mesh ID. Check the details and try again. RequestId: ${global.requestId}`,
+					`Unable to get mesh config. No mesh found for Org(${imsOrgCode}) -> Project(${projectId}) -> Workspace(${workspaceId}). Please check the details and try again.`,
+					{ exit: false },
 				);
 			} else if (error.message === 'NoActiveDeploymentFound') {
 				this.error(

--- a/src/commands/api-mesh/get.js
+++ b/src/commands/api-mesh/get.js
@@ -92,7 +92,7 @@ class GetCommand extends Command {
 			} catch (error) {
 				if (error.message === 'NoActiveDeploymentFound') {
 					this.error(
-						`No active deployment found for mesh ${meshId}. Check the mesh ID and try again or try without --active flag to get the mesh config. RequestId: ${global.requestId}`,
+						`No active deployment found for mesh ${meshId}. Check the mesh ID and try again or try without the --active flag. RequestId: ${global.requestId}`,
 					);
 				} else {
 					this.log(error.message);
@@ -111,6 +111,6 @@ class GetCommand extends Command {
 }
 
 GetCommand.description =
-	'Get the config of a given mesh. Use --active flag to retrieve the last successfully deployed mesh config';
+	'Get the config of a specified mesh. Use the --active flag to retrieve the last successfully deployed mesh config';
 
 module.exports = GetCommand;

--- a/src/commands/api-mesh/source/install.js
+++ b/src/commands/api-mesh/source/install.js
@@ -140,7 +140,7 @@ class InstallCommand extends Command {
 		}
 
 		try {
-			const mesh = await getMesh(imsOrgCode, projectId, workspaceId, meshId, workspaceName);
+			const mesh = await getMesh(imsOrgCode, projectId, workspaceId, workspaceName, meshId);
 
 			if (!mesh) {
 				this.error(

--- a/src/commands/api-mesh/source/install.js
+++ b/src/commands/api-mesh/source/install.js
@@ -140,7 +140,7 @@ class InstallCommand extends Command {
 		}
 
 		try {
-			const mesh = await getMesh(imsOrgCode, projectId, workspaceId, workspaceName, meshId);
+			const mesh = await getMesh(imsOrgCode, projectId, workspaceId, workspaceName);
 
 			if (!mesh) {
 				this.error(

--- a/src/commands/api-mesh/status.js
+++ b/src/commands/api-mesh/status.js
@@ -41,7 +41,7 @@ class StatusCommand extends Command {
 		}
 
 		try {
-			const mesh = await getMesh(imsOrgCode, projectId, workspaceId, workspaceName, meshId);
+			const mesh = await getMesh(imsOrgCode, projectId, workspaceId, workspaceName);
 			this.log(''.padEnd(102, '*'));
 			await this.displayMeshStatus(mesh, imsOrgCode, projectId, workspaceId);
 			this.log(''.padEnd(102, '*'));

--- a/src/lib/smsClient.js
+++ b/src/lib/smsClient.js
@@ -158,8 +158,8 @@ const listLogs = async (organizationCode, projectId, workspaceId, meshId, fileNa
 const getMesh = async (organizationId, projectId, workspaceId, workspaceName, meshId, active) => {
 	const { accessToken } = await getDevConsoleConfig();
 
-	const baseUrl = `${SMS_BASE_URL}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/meshes/${meshId}`;
-	const url = active ? baseUrl + `?active=${active}` : baseUrl;
+	const url = `${SMS_BASE_URL}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/meshes/${meshId}`;
+	const params = active ? { active } : undefined;
 
 	const config = {
 		method: 'get',
@@ -171,6 +171,7 @@ const getMesh = async (organizationId, projectId, workspaceId, workspaceName, me
 			'workspaceName': workspaceName,
 			'x-api-key': SMS_API_KEY,
 		},
+		params: params,
 	};
 
 	logger.info('Initiating GET %s', url);
@@ -203,8 +204,7 @@ const getMesh = async (organizationId, projectId, workspaceId, workspaceName, me
 			// Check if no active deployment found
 			if (
 				active &&
-				error.response.data?.message &&
-				error.response.data.message.includes('No active deployment found')
+				error.response.data?.message?.includes('No active deployment found')
 			) {
 				logger.error('No active deployment found for mesh');
 				throw new Error('NoActiveDeploymentFound');
@@ -683,7 +683,6 @@ const getMeshId = async (organizationCode, projectId, workspaceId, workspaceName
 			);
 		}
 	} catch (error) {
-		console.error(error.response.status);
 		if (error.response.status === 400) {
 			// The request was made and the server responded with a 400 status code
 			logger.error('Mesh not found');

--- a/src/lib/smsClient.js
+++ b/src/lib/smsClient.js
@@ -142,11 +142,28 @@ const listLogs = async (organizationCode, projectId, workspaceId, meshId, fileNa
 	}
 };
 
-const getMesh = async (organizationId, projectId, workspaceId, workspaceName, meshId) => {
+/**
+ * Retrieves mesh configuration from the Schema Management Service.
+ *
+ * @param {string} organizationId - The organization ID
+ * @param {string} projectId - The project ID
+ * @param {string} workspaceId - The workspace ID
+ * @param {string} workspaceName - The workspace name
+ * @param {string} meshId - The mesh ID
+ * @param {boolean} active - Whether to retrieve the last successful deployed mesh configuration.
+ * @returns {Promise<Object|null>} The mesh configuration object, or null if mesh not found
+ * @throws {Error} Throws 'NoActiveDeploymentFound' when active=true but no successful deployment exists
+ * @throws {Error} Throws generic error for other API failures
+ */
+const getMesh = async (organizationId, projectId, workspaceId, workspaceName, meshId, active) => {
 	const { accessToken } = await getDevConsoleConfig();
+
+	const baseUrl = `${SMS_BASE_URL}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/meshes/${meshId}`;
+	const url = active ? baseUrl + `?active=${active}` : baseUrl;
+
 	const config = {
 		method: 'get',
-		url: `${SMS_BASE_URL}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/meshes/${meshId}`,
+		url: url,
 		headers: {
 			...global?.metadataHeaders,
 			'Authorization': `Bearer ${accessToken}`,
@@ -156,10 +173,7 @@ const getMesh = async (organizationId, projectId, workspaceId, workspaceName, me
 		},
 	};
 
-	logger.info(
-		'Initiating GET %s',
-		`${SMS_BASE_URL}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/meshes/${meshId}`,
-	);
+	logger.info('Initiating GET %s', url);
 
 	try {
 		const response = await axios(config);
@@ -186,10 +200,19 @@ const getMesh = async (organizationId, projectId, workspaceId, workspaceName, me
 		logger.info('Response from GET %s', error.response.status);
 
 		if (error.response.status === 404) {
-			// The request was made and the server responded with a 404 status code
-			logger.error('Mesh not found');
-
-			return null;
+			// Check if no active deployment found
+			if (
+				active &&
+				error.response.data?.message &&
+				error.response.data.message.includes('No active deployment found')
+			) {
+				logger.error('No active deployment found for mesh');
+				throw new Error('NoActiveDeploymentFound');
+			} else {
+				// General mesh not found case
+				logger.error('Mesh not found');
+				return null;
+			}
 		} else if (error.response && error.response.data) {
 			// The request was made and the server responded with an unsupported status code
 			logger.error(

--- a/src/lib/smsClient.js
+++ b/src/lib/smsClient.js
@@ -149,16 +149,15 @@ const listLogs = async (organizationCode, projectId, workspaceId, meshId, fileNa
  * @param {string} projectId - The project ID
  * @param {string} workspaceId - The workspace ID
  * @param {string} workspaceName - The workspace name
- * @param {string} meshId - The mesh ID
  * @param {boolean} active - Whether to retrieve the last successful deployed mesh configuration.
  * @returns {Promise<Object|null>} The mesh configuration object, or null if mesh not found
  * @throws {Error} Throws 'NoActiveDeploymentFound' when active=true but no successful deployment exists
  * @throws {Error} Throws generic error for other API failures
  */
-const getMesh = async (organizationId, projectId, workspaceId, workspaceName, meshId, active) => {
+const getMesh = async (organizationId, projectId, workspaceId, workspaceName, active) => {
 	const { accessToken } = await getDevConsoleConfig();
 
-	const url = `${SMS_BASE_URL}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/meshes/${meshId}`;
+	const url = `${SMS_BASE_URL}/organizations/${organizationId}/projects/${projectId}/workspaces/${workspaceId}/mesh`;
 	const params = active ? { active } : undefined;
 
 	const config = {
@@ -208,7 +207,7 @@ const getMesh = async (organizationId, projectId, workspaceId, workspaceName, me
 			} else {
 				// General mesh not found case
 				logger.error('Mesh not found');
-				return null;
+				throw new Error('MeshIdNotFound');
 			}
 		} else if (error.response && error.response.data) {
 			// The request was made and the server responded with an unsupported status code

--- a/src/lib/smsClient.js
+++ b/src/lib/smsClient.js
@@ -683,6 +683,7 @@ const getMeshId = async (organizationCode, projectId, workspaceId, workspaceName
 			);
 		}
 	} catch (error) {
+		console.error(error.response.status);
 		if (error.response.status === 400) {
 			// The request was made and the server responded with a 400 status code
 			logger.error('Mesh not found');

--- a/src/lib/smsClient.js
+++ b/src/lib/smsClient.js
@@ -207,7 +207,7 @@ const getMesh = async (organizationId, projectId, workspaceId, workspaceName, ac
 			} else {
 				// General mesh not found case
 				logger.error('Mesh not found');
-				throw new Error('MeshIdNotFound');
+				throw new Error('MeshNotFound');
 			}
 		} else if (error.response && error.response.data) {
 			// The request was made and the server responded with an unsupported status code

--- a/src/lib/smsClient.js
+++ b/src/lib/smsClient.js
@@ -202,10 +202,7 @@ const getMesh = async (organizationId, projectId, workspaceId, workspaceName, me
 
 		if (error.response.status === 404) {
 			// Check if no active deployment found
-			if (
-				active &&
-				error.response.data?.message?.includes('No active deployment found')
-			) {
+			if (active && error.response.data?.message?.includes('No active deployment found')) {
 				logger.error('No active deployment found for mesh');
 				throw new Error('NoActiveDeploymentFound');
 			} else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,6 +70,12 @@ const inspectPortNoFlag = Flags.integer({
 	default: 9229,
 });
 
+const activeFlag = Flags.boolean({
+	char: 'a',
+	description: 'Retrieve the last successfully deployed mesh config',
+	default: false,
+});
+
 const debugFlag = Flags.boolean({
 	description: 'Enable debugging mode',
 	default: false,
@@ -815,6 +821,7 @@ module.exports = {
 	getAppRootDir,
 	portNoFlag,
 	inspectPortNoFlag,
+	activeFlag,
 	debugFlag,
 	selectFlag,
 	secretsFlag,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added --active flag in get command , to retrieve last successfull deployed mesh.

## Description

`aio api-mesh get`  should accept --active flag.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Command Description 
<img width="503" height="138" alt="image" src="https://github.com/user-attachments/assets/5d22e892-93e2-466c-a361-d903496ef4ef" />

Default behavior should still work as is
1. `aio api-mesh get` : returns mesconfig
<img width="455" height="407" alt="image" src="https://github.com/user-attachments/assets/14c1640d-7cff-4c25-b881-ecaf2f56d159" />

With --active flag changes 
1. `aio api-mesh get --active` or `aio api-mesh get --a` : should return last successful deployed meshConfig
create a valid mesh -- both should return same meshCOnfig if successfully deployed
<img width="476" height="286" alt="image" src="https://github.com/user-attachments/assets/e56f3cc6-7023-43b2-9560-eb0112562355" />
<img width="509" height="426" alt="image" src="https://github.com/user-attachments/assets/5da92e8a-33b8-4dc0-8ec9-c6ebd569047e" />

update with invalid mesh which failed at build -- default should return failed meshConfig and with ---active the valid mesh created should be returned
<img width="526" height="342" alt="image" src="https://github.com/user-attachments/assets/9904bb56-ae7b-4fd6-9dba-4590e1f98ac6" />
--active 
<img width="476" height="431" alt="image" src="https://github.com/user-attachments/assets/d5da12b3-bc56-4a37-96b9-63b7765142e0" />
Default 
<img width="706" height="462" alt="image" src="https://github.com/user-attachments/assets/d13c070f-f901-414e-b27f-9b727dd2f5ed" />

2. . `aio api-mesh get --active` or `aio api-mesh get --a` : should return no active deployment found
<img width="776" height="64" alt="image" src="https://github.com/user-attachments/assets/f7509a96-0e5e-47ff-8b6d-40606ab5d048" />
<img width="787" height="64" alt="image" src="https://github.com/user-attachments/assets/80c1f91a-c5e1-43e2-bac4-d28247884469" />


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
