### PR TITLE
Added support for .graphql files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/setup-node@v3
           with:
-            node-version: 24
+            node-version: 22
         - run: yarn global add @adobe/aio-cli
         - run: yarn install --frozen-lockfile
         - run: yarn run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/setup-node@v3
           with:
-            node-version: 18
+            node-version: 24
         - run: yarn global add @adobe/aio-cli
         - run: yarn install --frozen-lockfile
         - run: yarn run lint

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Yarn install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Yarn install
         run: yarn install --frozen-lockfile

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -1000,7 +1000,7 @@ describe('create command tests', () => {
 	`);
 	});
 
-	test('should fail if the file is of type other than js, json extension', async () => {
+	test('should fail if the file is of type other than js, json or graphql extension', async () => {
 		parseSpy.mockResolvedValueOnce({
 			args: { file: 'src/commands/__fixtures__/sample_mesh_invalid_type.json' },
 			flags: {

--- a/src/commands/api-mesh/__tests__/create.test.js
+++ b/src/commands/api-mesh/__tests__/create.test.js
@@ -1015,7 +1015,7 @@ describe('create command tests', () => {
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Mesh files must be JavaScript or JSON. Other file types are not supported. The following file(s) are invalid: requestParams.txt.",
+		    "Mesh files must be JavaScript, JSON or GraphQL. Other file types are not supported. The following file(s) are invalid: requestParams.txt.",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/run.test.js
+++ b/src/commands/api-mesh/__tests__/run.test.js
@@ -541,7 +541,7 @@ describe('run command tests', () => {
 		expect(logSpy.mock.calls).toMatchInlineSnapshot(`
 		[
 		  [
-		    "Mesh files must be JavaScript or JSON. Other file types are not supported. The following file(s) are invalid: requestParams.txt.",
+		    "Mesh files must be JavaScript, JSON or GraphQL. Other file types are not supported. The following file(s) are invalid: requestParams.txt.",
 		  ],
 		]
 	`);

--- a/src/commands/api-mesh/__tests__/run.test.js
+++ b/src/commands/api-mesh/__tests__/run.test.js
@@ -526,7 +526,7 @@ describe('run command tests', () => {
 	`);
 	});
 
-	test('should fail if the file is of type other than js, json extension', async () => {
+	test('should fail if the file is of type other than js, json or graphql extension', async () => {
 		parseSpy.mockResolvedValueOnce({
 			args: { file: 'src/commands/__fixtures__/sample_mesh_invalid_type.json' },
 			flags: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -357,7 +357,7 @@ function validateFileType(filesList) {
 
 	filesList.forEach(file => {
 		const extension = path.extname(file);
-		const isValidFileType = ['.js', '.json'].includes(extension);
+		const isValidFileType = ['.js', '.json', '.graphql'].includes(extension);
 
 		if (!isValidFileType) {
 			filesWithInvalidTypes.push(path.basename(file));
@@ -366,7 +366,7 @@ function validateFileType(filesList) {
 
 	if (filesWithInvalidTypes.length) {
 		throw new Error(
-			`Mesh files must be JavaScript or JSON. Other file types are not supported. The following file(s) are invalid: ${filesWithInvalidTypes}.`,
+			`Mesh files must be JavaScript, JSON or GraphQL. Other file types are not supported. The following file(s) are invalid: ${filesWithInvalidTypes}.`,
 		);
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change allows the CLI to accept `.graphql` files while building meshes in the run command or submitting a mesh for create/update in their respective commands.

## Related Issue

https://jira.corp.adobe.com/browse/CEXT-4955

## Motivation and Context

A bug not allowing customers to upload `.graphql` files.

## How Has This Been Tested?

Local link

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
